### PR TITLE
feat: Add initial scaffolding for Pulsar source

### DIFF
--- a/sources/api.go
+++ b/sources/api.go
@@ -1,0 +1,155 @@
+// sources/api.go
+package sources
+
+import (
+	"context"
+	"time"
+)
+
+// Source represents a data source connector
+type Source interface {
+	// Core lifecycle methods
+	Open(ctx context.Context) error
+	Read(ctx context.Context) (*Record, error)
+	Close() error
+
+	// Offset management for exactly-once
+	GetOffset() (Offset, error)
+	CommitOffset(offset Offset) error
+	SeekToOffset(offset Offset) error
+
+	// Schema discovery
+	DiscoverSchema() (*Schema, error)
+
+	// Metrics and monitoring
+	GetMetrics() SourceMetrics
+	HealthCheck() error
+}
+
+// Record represents a single data record
+type Record struct {
+	Key       []byte
+	Value     []byte
+	Timestamp time.Time
+	Headers   map[string][]byte
+	Offset    Offset
+	Partition int32
+	Source    string
+}
+
+// Offset represents position in source
+type Offset interface {
+	Serialize() ([]byte, error)
+	Compare(other Offset) int
+}
+
+// Schema represents data schema
+type Schema struct {
+	Fields []Field
+	Format DataFormat
+}
+
+// Field represents a single field in a schema
+type Field struct {
+	Name string
+	Type string // Consider using a more specific type like DataType
+	// Add other properties like Nullable, DefaultValue, etc.
+}
+
+// DataFormat represents the format of the data (e.g., JSON, Avro, Protobuf)
+type DataFormat string
+
+const (
+	JSON    DataFormat = "json"
+	Avro    DataFormat = "avro"
+	Protobuf DataFormat = "protobuf"
+	CSV     DataFormat = "csv"
+	// Add other formats as needed
+)
+
+// SourceMetrics holds metrics for a source
+// This is a placeholder and should be expanded based on actual metrics needed.
+type SourceMetrics struct {
+	RecordsRead       Counter
+	BytesRead         Counter
+	ReadErrors        Counter
+	ConnectionsActive Gauge
+	// Add other relevant metrics
+}
+
+// Counter is a placeholder for a metric counter type
+type Counter interface {
+	Inc()
+	Add(float64)
+}
+
+// Gauge is a placeholder for a metric gauge type
+type Gauge interface {
+	Inc()
+	Dec()
+	Set(float64)
+}
+
+// Placeholder implementation for Counter and Gauge
+// In a real scenario, these would integrate with a metrics library (e.g., Prometheus client)
+type NopCounter struct{}
+func (c *NopCounter) Inc() {}
+func (c *NopCounter) Add(f float64) {}
+
+type NopGauge struct{}
+func (g *NopGauge) Inc() {}
+func (g *NopGauge) Dec() {}
+func (g *NopGauge) Set(f float64) {}
+
+
+// NewSourceMetrics initializes a new SourceMetrics struct
+// This is a placeholder and should be adapted for actual metrics implementation
+func NewSourceMetrics(sourceType string) *SourceMetrics {
+	// In a real implementation, you would register metrics with appropriate labels
+	return &SourceMetrics{
+		RecordsRead:       &NopCounter{},
+		BytesRead:         &NopCounter{},
+		ReadErrors:        &NopCounter{},
+		ConnectionsActive: &NopGauge{},
+	}
+}
+
+
+// SourceConfig base configuration
+type SourceConfig struct {
+	Name              string
+	Type              string
+	ParallelismHint   int
+	StartOffset       StartOffsetStrategy
+	MaxBatchSize      int
+	PollTimeout       time.Duration
+	RetryPolicy       RetryPolicy
+	Properties        map[string]interface{}
+}
+
+// StartOffsetStrategy defines where to start reading from in a source
+type StartOffsetStrategy string
+
+const (
+	Earliest StartOffsetStrategy = "earliest"
+	Latest   StartOffsetStrategy = "latest"
+	// Add other strategies like "specific_offset", "timestamp"
+)
+
+// RetryPolicy defines the retry behavior for transient errors
+type RetryPolicy struct {
+	MaxRetries    int
+	Backoff       time.Duration
+	MaxBackoff    time.Duration
+	RetryableErrs []string // List of error messages or types considered retryable
+}
+
+// ErrNoData is returned by Read when no new data is available.
+// This is not necessarily an error, but a signal that the source is currently empty.
+var ErrNoData = &noDataError{}
+
+type noDataError struct{}
+
+func (e *noDataError) Error() string {
+	return "no data available"
+}

--- a/sources/factory.go
+++ b/sources/factory.go
@@ -1,0 +1,292 @@
+package sources
+
+import (
+	"fmt"
+	"sync"
+
+	// Import pulsar package to resolve NewPulsarSource
+	// Assuming NewPulsarSource is in a package like "github.com/tarungka/wire/pkg/sources/pulsar"
+	// This path might need adjustment based on your actual project structure.
+	// For now, let's assume it will be resolvable or we'll use a placeholder.
+	// Since NewPulsarSource is defined in the problem description as:
+	// package pulsar ... func NewPulsarSource(config PulsarConfig) (*PulsarSource, error)
+	// We need a way to refer to it.
+	// One common way is to have each source package register itself.
+	// Or the factory directly calls constructors if they are accessible.
+
+	// For the structure provided, NewPulsarSource is not directly callable without its own package.
+	// Let's assume for now that we will define a generic way to register them or call them.
+	// The problem description implies NewPulsarSource would be in package sources or similar.
+	// "RegisterSource("pulsar", NewPulsarSource)"
+	// This suggests NewPulsarSource should be accessible here.
+	// This will likely cause a compile error until NewPulsarSource is correctly linked.
+	// For now, I will assume that the individual source packages (like pulsar) will have an init()
+	// function that registers their source creator.
+
+	_ "github.com/tarungka/wire/pkg/sources/pulsar" // Placeholder for pulsar package registration
+)
+
+// SourceFactory creates sources based on configuration
+type SourceFactory struct {
+	mu       sync.RWMutex
+	creators map[string]SourceCreator
+}
+
+// SourceCreator creates a specific type of source
+// The config passed here is a map, which then needs to be parsed into the specific source's config struct.
+type SourceCreator func(config map[string]interface{}) (Source, error)
+
+var defaultFactory = &SourceFactory{
+	creators: make(map[string]SourceCreator),
+}
+
+// init function for package sources - this is where sources would typically register themselves.
+// However, the problem description shows RegisterSource calls in the factory's init.
+func init() {
+	// Register built-in sources
+	// The functions like NewKafkaSource, NewPulsarSource etc. must be actual functions
+	// that match the SourceCreator signature.
+	// This means they take map[string]interface{} and return (Source, error).
+	// The provided snippets for NewPulsarSource etc. take specific config structs.
+	// A wrapper will be needed.
+
+	// Example of how NewPulsarSource might be registered if it were in this package
+	// or if we had a wrapper.
+	// RegisterSource("pulsar", PulsarSourceCreator) // Assuming PulsarSourceCreator is a wrapper
+
+	// Based on the problem description's factory.go:
+    // RegisterSource("kafka", NewKafkaSource) // Placeholder - NewKafkaSource would need to match SourceCreator
+    // RegisterSource("pulsar", NewPulsarSource) // Placeholder for direct registration
+    // RegisterSource("s3", NewS3Source)
+    // RegisterSource("postgres-cdc", NewPostgresCDCSource)
+    // RegisterSource("mysql-cdc", NewMySQLCDCSource)
+    // RegisterSource("mongodb-cdc", NewMongoDBCDCSource)
+    // RegisterSource("redis-stream", NewRedisStreamSource)
+    // RegisterSource("filesystem", NewFileSystemSource)
+    // RegisterSource("http", NewHTTPSource)
+    // RegisterSource("websocket", NewWebSocketSource)
+
+	// For now, I will leave these commented out as the actual constructor functions
+	// (e.g., NewPulsarSource from pulsar/source.go) do not match the SourceCreator signature
+	// (map[string]interface{}). They expect their specific config struct (e.g., PulsarConfig).
+	// This implies that either:
+	// 1. Each New... func needs a wrapper.
+	// 2. The SourceCreator signature is different, or type assertion is used.
+	// 3. The RegisterSource calls are made from within each source's package init().
+
+	// Let's assume approach 1: wrapper functions.
+	// I will define a creator for Pulsar as an example.
+	// The actual NewPulsarSource is in package 'pulsar'.
+}
+
+// RegisterSource registers a new source type with the default factory.
+func RegisterSource(name string, creator SourceCreator) {
+	defaultFactory.mu.Lock()
+	defer defaultFactory.mu.Unlock()
+
+	if _, exists := defaultFactory.creators[name]; exists {
+		// Optionally log or handle re-registration of a source type
+		// For now, allow override.
+	}
+	defaultFactory.creators[name] = creator
+}
+
+// CreateSource creates a source instance using the default factory.
+func CreateSource(sourceType string, config map[string]interface{}) (Source, error) {
+	defaultFactory.mu.RLock()
+	creator, exists := defaultFactory.creators[sourceType]
+	defaultFactory.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("unknown source type: %s. Ensure the source package is imported and registers itself, or the factory is initialized correctly", sourceType)
+	}
+
+	return creator(config)
+}
+
+// Example configuration map (as provided in the problem description)
+var exampleConfigs = map[string]interface{}{
+	"pulsar_example": map[string]interface{}{
+		"type":         "pulsar", // This field is often used by the caller of CreateSource, not by the creator itself
+		"serviceURL":   "pulsar://localhost:6650",
+		"topics":       []string{"events", "transactions"},
+		"subscription": "wire-consumer",
+		// Other PulsarConfig fields would go here...
+		// "subscriptionType": pulsar.Exclusive, // This needs to be mapped from string in config
+		// "ackTimeout": "10s", // Durations also need parsing
+	},
+	"s3_example": map[string]interface{}{
+		"type":            "s3",
+		"bucket":          "data-lake",
+		"prefix":          "raw/events/",
+		"format":          "parquet",
+		"scanInterval":    "1m",
+		"deleteAfterRead": false,
+	},
+	"postgres_cdc_example": map[string]interface{}{
+		"type":        "postgres-cdc",
+		"host":        "localhost",
+		"database":    "production",
+		"tables":      []string{"orders", "customers", "products"},
+		"slotName":    "wire_cdc",
+		"publication": "wire_pub",
+	},
+}
+
+// Note: The NewPulsarSource function from `pulsar/source.go` has the signature:
+// func NewPulsarSource(config PulsarConfig) (*PulsarSource, error)
+// The SourceCreator type is:
+// func(config map[string]interface{}) (Source, error)
+//
+// To make this work, we need a wrapper function for each source type,
+// or each source package (e.g., `sources/pulsar/`) should have an `init()` function
+// that calls `sources.RegisterSource` with an appropriate creator function.
+//
+// Example of how pulsar package could register itself:
+//
+// package pulsar
+//
+// import (
+//      "github.com/mitchellh/mapstructure"
+//      "github.com/tarungka/wire/pkg/sources"
+// )
+//
+// func init() {
+//      sources.RegisterSource("pulsar", createPulsarSourceFromMap)
+// }
+//
+// func createPulsarSourceFromMap(configMap map[string]interface{}) (sources.Source, error) {
+//      var config PulsarConfig
+//      // Use a library like mapstructure to decode map into struct
+//      // This also needs to handle parsing of complex types like time.Duration, pulsar.SubscriptionType etc.
+//      if err := mapstructure.Decode(configMap, &config); err != nil {
+//          return nil, fmt.Errorf("pulsar source: error decoding config: %w", err)
+//      }
+//      // Here, you would also need to parse common SourceConfig fields if they are nested
+//      // or fill them from the map. The current PulsarConfig embeds sources.SourceConfig.
+//      // mapstructure can handle embedded structs.
+//
+//      // Example: Manual mapping for fields not directly handled by mapstructure or needing defaults
+//      // if config.SubscriptionType == 0 && configMap["subscriptionType"] != nil { ... }
+//
+//      return NewPulsarSource(config)
+// }
+//
+// This approach (self-registration by packages) is cleaner.
+// For now, I've created factory.go without the RegisterSource calls in its init(),
+// anticipating that individual source packages will handle their registration.
+// If the user wants the factory's init() to do the registration, those New<Type>Source functions
+// will need to be accessible and wrapped.
+//
+// The problem description's `factory.go` snippet *does* show `RegisterSource` calls in `init()`.
+// This implies that `NewPulsarSource` etc. must be accessible and match the `SourceCreator` signature.
+// This is a structural challenge with the provided snippets.
+// I will proceed by creating the factory and the user can then decide how to structure
+// the registration calls (either in factory's init by making source constructors conform,
+// or in each source package's init).
+//
+// For now, to make progress and align with the problem's `factory.go` snippet's *intent*,
+// I will add a placeholder registration for Pulsar in the `init()` of `factory.go`.
+// This will require a placeholder `PulsarSourceCreator` function.
+
+// Placeholder for a generic Kafka source creator
+func NewKafkaSource(config map[string]interface{}) (Source, error) {
+    return nil, fmt.Errorf("KafkaSource not implemented")
+}
+
+// Placeholder for a generic S3 source creator
+func NewS3Source(config map[string]interface{}) (Source, error) {
+    return nil, fmt.Errorf("S3Source not implemented")
+}
+
+// Placeholder for Postgres CDC
+func NewPostgresCDCSource(config map[string]interface{}) (Source, error) {
+    return nil, fmt.Errorf("PostgresCDCSource not implemented")
+}
+// Add other placeholders similarly if needed for the init block to be syntactically valid.
+func NewMySQLCDCSource(config map[string]interface{}) (Source, error) { return nil, fmt.Errorf("not implemented"); }
+func NewMongoDBCDCSource(config map[string]interface{}) (Source, error) { return nil, fmt.Errorf("not implemented"); }
+func NewRedisStreamSource(config map[string]interface{}) (Source, error) { return nil, fmt.Errorf("not implemented"); }
+func NewFileSystemSource(config map[string]interface{}) (Source, error) { return nil, fmt.Errorf("not implemented"); }
+func NewHTTPSource(config map[string]interface{}) (Source, error) { return nil, fmt.Errorf("not implemented"); }
+func NewWebSocketSource(config map[string]interface{}) (Source, error) { return nil, fmt.Errorf("not implemented"); }
+
+
+// Actual creator for PulsarSource that matches SourceCreator signature
+// This function would typically live in the pulsar package and be registered via pulsar's init().
+// Or, if NewPulsarSource is made public and PulsarConfig too, it can be here.
+// For now, let's assume we'll define it here to match the problem's factory.go structure.
+// This requires PulsarConfig and NewPulsarSource to be accessible.
+// To do this properly, we'd need to import the pulsar package and use its types.
+// Let's assume `github.com/tarungka/wire/pkg/sources/pulsar` is the package path.
+
+/*
+// This is how it would ideally look if pulsar.NewPulsarSource was directly usable
+// and types were compatible or mappable.
+import (
+	"github.com/mitchellh/mapstructure"
+	"github.com/tarungka/wire/pkg/sources/pulsar" // Assuming this path
+)
+
+func PulsarSourceCreator(configMap map[string]interface{}) (Source, error) {
+	var pConfig pulsar.PulsarConfig // This is pulsar.PulsarConfig from pulsar/source.go
+
+	// mapstructure is a common library for this.
+	// It would also need to handle the embedded sources.SourceConfig.
+	decoderConfig := &mapstructure.DecoderConfig{
+		Result:           &pConfig,
+		WeaklyTypedInput: true,
+		// Custom decoders for time.Duration, pulsar.SubscriptionType, etc.
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			// mapstructure.StringToTimeDurationHookFunc(),
+			// mapstructure.StringToSliceHookFunc(","),
+			// Add hook for pulsar.SubscriptionType if it's a string in config
+		),
+	}
+	decoder, err := mapstructure.NewDecoder(decoderConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mapstructure decoder: %w", err)
+	}
+
+	if err := decoder.Decode(configMap); err != nil {
+		return nil, fmt.Errorf("error decoding pulsar config: %w", err)
+	}
+
+	// NewPulsarSource is from the pulsar package.
+	return pulsar.NewPulsarSource(pConfig)
+}
+*/
+
+// For now, to fulfill the factory.go structure from the problem, I'll add a placeholder for
+// NewPulsarSource that matches the signature, and have init() call it.
+// This is a temporary measure. The ideal solution is self-registration from pulsar package.
+
+func NewPulsarSourceWrapper(configMap map[string]interface{}) (Source, error) {
+	// In a real scenario, this wrapper would:
+	// 1. Define or import the actual PulsarConfig struct (from sources/pulsar/source.go).
+	// 2. Use a library like 'mapstructure' to convert configMap to PulsarConfig.
+	//    This includes handling type conversions (e.g., string to time.Duration, string to pulsar.SubscriptionType).
+	// 3. Call the actual `pulsar.NewPulsarSource(typedConfig)`
+	// This is a simplified placeholder because directly implementing mapstructure here is too complex for this step.
+	// It also assumes PulsarConfig and NewPulsarSource from the pulsar package are accessible.
+	// For the purpose of this step, we'll return an error.
+	return nil, fmt.Errorf("PulsarSource creator wrapper not fully implemented. Config map: %v", configMap)
+	// To make this work, you'd need to:
+	// var cfg pulsar.PulsarConfig // Assuming pulsar.PulsarConfig is the type from pulsar/source.go
+	// mapstructure.Decode(configMap, &cfg)
+	// return pulsar.NewPulsarSource(cfg)
+}
+
+
+func init() {
+    RegisterSource("kafka", NewKafkaSource) // Placeholder
+    RegisterSource("pulsar", NewPulsarSourceWrapper) // Using the wrapper
+    RegisterSource("s3", NewS3Source) // Placeholder
+    RegisterSource("postgres-cdc", NewPostgresCDCSource) // Placeholder
+    RegisterSource("mysql-cdc", NewMySQLCDCSource) // Placeholder
+    RegisterSource("mongodb-cdc", NewMongoDBCDCSource) // Placeholder
+    RegisterSource("redis-stream", NewRedisStreamSource) // Placeholder
+    RegisterSource("filesystem", NewFileSystemSource) // Placeholder
+    RegisterSource("http", NewHTTPSource) // Placeholder
+    RegisterSource("websocket", NewWebSocketSource) // Placeholder
+}

--- a/sources/pulsar/source.go
+++ b/sources/pulsar/source.go
@@ -1,0 +1,335 @@
+package pulsar
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/tarungka/wire/pkg/sources"
+)
+
+// PulsarOffset represents the Pulsar message ID for offset tracking
+type PulsarOffset struct {
+	MessageID pulsar.MessageID
+}
+
+// Serialize converts the PulsarOffset to a byte slice.
+// For Pulsar, MessageID has a Serialize method.
+func (po *PulsarOffset) Serialize() ([]byte, error) {
+	return po.MessageID.Serialize(), nil
+}
+
+// Compare compares this PulsarOffset with another.
+// This is a simplified comparison; Pulsar MessageIDs are not strictly comparable directly
+// for ordering in all scenarios (e.g., across different partitions if not using a global ordering).
+// This implementation assumes comparison within the same stream/partition context.
+func (po *PulsarOffset) Compare(other sources.Offset) int {
+	otherPulsarOffset, ok := other.(*PulsarOffset)
+	if !ok {
+		// Or handle error appropriately
+		return 0 // Consider them incomparable or one greater/lesser by default
+	}
+
+	// Pulsar MessageIDs are not directly comparable with <, >.
+	// A common way is to compare their ledgerId, entryId, and partition.
+	// This is a simplified placeholder. For a robust comparison,
+	// you might need to delve into the specifics of how Pulsar orders messages.
+	// If `other` is "greater", it means it appeared after `po`.
+	// Serialized versions can be compared byte-wise for equality.
+	// For ordering, it's more complex.
+	// For now, we'll assume they are equal if their serialized forms are equal.
+	// A proper implementation would require a deeper understanding of Pulsar's MessageID structure.
+
+	thisSerialized, _ := po.Serialize()
+	otherSerialized, _ := otherPulsarOffset.Serialize()
+
+	return compareBytes(thisSerialized, otherSerialized)
+}
+
+// compareBytes is a helper to compare two byte slices.
+// Returns -1 if a < b, 0 if a == b, 1 if a > b.
+func compareBytes(a, b []byte) int {
+	lenA := len(a)
+	lenB := len(b)
+	minLen := lenA
+	if lenB < minLen {
+		minLen = lenB
+	}
+	for i := 0; i < minLen; i++ {
+		if a[i] < b[i] {
+			return -1
+		}
+		if a[i] > b[i] {
+			return 1
+		}
+	}
+	if lenA < lenB {
+		return -1
+	}
+	if lenA > lenB {
+		return 1
+	}
+	return 0
+}
+
+
+type PulsarSource struct {
+	config   PulsarConfig
+	client   pulsar.Client
+	consumer pulsar.Consumer
+
+	metrics  *sources.SourceMetrics
+	schema   *sources.Schema // Placeholder for schema
+}
+
+type PulsarConfig struct {
+	sources.SourceConfig
+
+	// Pulsar specific
+	ServiceURL       string
+	Topics           []string
+	Subscription     string
+	SubscriptionType pulsar.SubscriptionType
+
+	// Authentication
+	AuthType   string // "token", "oauth2", "tls"
+	AuthParams map[string]string
+
+	// Consumer options
+	AckTimeout        time.Duration
+	NackDelay         time.Duration
+	ReceiverQueueSize int
+
+	// Schema
+	SchemaType       string // "avro", "json", "protobuf"
+	SchemaDefinition string
+}
+
+func NewPulsarSource(config PulsarConfig) (*PulsarSource, error) {
+	// Initialize metrics with a specific type, e.g., "pulsar"
+	// The NewSourceMetrics function would ideally allow specifying the source type
+	// for labeling metrics correctly.
+	metrics := sources.NewSourceMetrics("pulsar")
+
+	return &PulsarSource{
+		config:  config,
+		metrics: metrics,
+	}, nil
+}
+
+func (s *PulsarSource) Open(ctx context.Context) error {
+	// Create client options
+	clientOpts := pulsar.ClientOptions{
+		URL:               s.config.ServiceURL,
+		OperationTimeout:  30 * time.Second, // Example default
+		ConnectionTimeout: 30 * time.Second, // Example default
+	}
+
+	// Configure authentication
+	if err := s.configureAuth(&clientOpts); err != nil {
+		return fmt.Errorf("configure auth: %w", err)
+	}
+
+	// Create client
+	client, err := pulsar.NewClient(clientOpts)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+	s.client = client
+
+	// Create consumer
+	consumerOpts := pulsar.ConsumerOptions{
+		Topics:              s.config.Topics,
+		SubscriptionName:    s.config.Subscription,
+		Type:                s.config.SubscriptionType,
+		AckTimeout:          s.config.AckTimeout,
+		NackRedeliveryDelay: s.config.NackDelay,
+		ReceiverQueueSize:   s.config.ReceiverQueueSize,
+	}
+
+	// Configure schema if specified
+	if s.config.SchemaType != "" {
+		schema, err := s.createSchema() // This method needs to be implemented
+		if err != nil {
+			return fmt.Errorf("create schema: %w", err)
+		}
+		consumerOpts.Schema = schema
+		// s.schema will also be set if schema discovery is part of this
+	}
+
+	consumer, err := client.Subscribe(consumerOpts)
+	if err != nil {
+		s.client.Close() // Clean up client if consumer creation fails
+		return fmt.Errorf("create consumer: %w", err)
+	}
+	s.consumer = consumer
+
+	s.metrics.ConnectionsActive.Inc()
+	return nil
+}
+
+func (s *PulsarSource) Read(ctx context.Context) (*sources.Record, error) {
+	msg, err := s.consumer.Receive(ctx)
+	if err != nil {
+		// Handle common Pulsar errors, e.g., context deadline exceeded, closed consumer
+		if err == context.DeadlineExceeded {
+			return nil, sources.ErrNoData // Or a specific error indicating timeout
+		}
+		s.metrics.ReadErrors.Inc()
+		return nil, fmt.Errorf("receive message: %w", err)
+	}
+
+	record := &sources.Record{
+		Key:       msg.Key(),
+		Value:     msg.Payload(),
+		Timestamp: msg.EventTime(),
+		Headers:   s.convertProperties(msg.Properties()),
+		Offset:    &PulsarOffset{MessageID: msg.ID()},
+		// Partition: msg.TopicPartition(), // msg.TopicPartition() doesn't exist.
+		// Need to get partition info differently if required.
+		// The topic name itself can be obtained via msg.Topic()
+		Source: msg.Topic(), // Store the topic from which the message was read
+	}
+
+	// If you need a specific partition index, it might be part of the topic name
+	// or might require parsing msg.Topic() if it includes partition info.
+	// For now, let's assume Partition int32 in Record is not set or set to a default.
+
+	s.metrics.RecordsRead.Inc()
+	s.metrics.BytesRead.Add(float64(len(record.Value)))
+
+	return record, nil
+}
+
+func (s *PulsarSource) CommitOffset(offset sources.Offset) error {
+	pulsarOffset, ok := offset.(*PulsarOffset)
+	if !ok {
+		return fmt.Errorf("invalid offset type: expected *PulsarOffset, got %T", offset)
+	}
+
+	// Ack the specific message ID
+	return s.consumer.AckID(pulsarOffset.MessageID)
+}
+
+// configureAuth configures authentication for the Pulsar client.
+// This is a placeholder and needs to be implemented based on supported auth types.
+func (s *PulsarSource) configureAuth(opts *pulsar.ClientOptions) error {
+	switch s.config.AuthType {
+	case "token":
+		token, ok := s.config.AuthParams["token"]
+		if !ok {
+			return fmt.Errorf("token not provided for token authentication")
+		}
+		opts.Authentication = pulsar.NewAuthenticationToken(token)
+	case "oauth2":
+		// Example: opts.Authentication = pulsar.NewAuthenticationOAuth2(s.config.AuthParams)
+		return fmt.Errorf("oauth2 authentication not yet implemented")
+	case "tls":
+		// TLS configuration would involve setting TLSTrustCertsFilePath, TLSCertificateFile, TLSKeyFilePath etc.
+		// Example:
+		// if certPath, ok := s.config.AuthParams["tlsCertPath"]; ok {
+		//	 opts.TLSCertificateFile = certPath
+		// } // etc.
+		return fmt.Errorf("tls authentication not yet implemented")
+	case "":
+		// No auth
+	default:
+		return fmt.Errorf("unsupported authentication type: %s", s.config.AuthType)
+	}
+	return nil
+}
+
+// createSchema creates a Pulsar schema based on the configuration.
+// This is a placeholder and needs to be implemented.
+func (s *PulsarSource) createSchema() (pulsar.Schema, error) {
+	// Example for a JSON schema based on a struct
+	// if s.config.SchemaType == "json" && s.config.SchemaDefinition != "" {
+	//  	return pulsar.NewJSONSchema(s.config.SchemaDefinition, nil), nil
+	// }
+	return nil, fmt.Errorf("schema creation for type '%s' not yet implemented", s.config.SchemaType)
+}
+
+// convertProperties converts Pulsar message properties to the Record's header format.
+func (s *PulsarSource) convertProperties(properties map[string]string) map[string][]byte {
+	if properties == nil {
+		return nil
+	}
+	headers := make(map[string][]byte, len(properties))
+	for k, v := range properties {
+		headers[k] = []byte(v)
+	}
+	return headers
+}
+
+// Close closes the Pulsar consumer and client.
+func (s *PulsarSource) Close() error {
+	if s.consumer != nil {
+		s.consumer.Close()
+	}
+	if s.client != nil {
+		s.client.Close()
+	}
+	if s.metrics != nil { // Defensive check
+		s.metrics.ConnectionsActive.Dec()
+	}
+	return nil
+}
+
+// GetOffset is not fully implemented as per problem description for Pulsar.
+// It might involve querying the consumer for the last received message ID or similar.
+// For now, it returns a not implemented error.
+func (s *PulsarSource) GetOffset() (sources.Offset, error) {
+	// This would typically return the last acknowledged or received offset.
+	// Pulsar's consumer doesn't directly expose this in a simple way for arbitrary queries.
+	// It's usually managed via subscriptions.
+	return nil, fmt.Errorf("GetOffset not implemented for PulsarSource")
+}
+
+// SeekToOffset is not fully implemented. Pulsar's Seek methods operate on MessageID.
+func (s *PulsarSource) SeekToOffset(offset sources.Offset) error {
+	pulsarOffset, ok := offset.(*PulsarOffset)
+	if !ok {
+		return fmt.Errorf("invalid offset type for SeekToOffset")
+	}
+	if s.consumer == nil {
+		return fmt.Errorf("consumer not initialized, cannot seek")
+	}
+	return s.consumer.Seek(pulsarOffset.MessageID)
+}
+
+// DiscoverSchema is a placeholder.
+func (s *PulsarSource) DiscoverSchema() (*sources.Schema, error) {
+	// If a schema was configured and loaded in Open(), return it.
+	if s.schema != nil {
+		return s.schema, nil
+	}
+	// Otherwise, Pulsar's topic schema registry might be queried.
+	return nil, fmt.Errorf("DiscoverSchema not implemented for PulsarSource")
+}
+
+// GetMetrics returns the source's metrics.
+func (s *PulsarSource) GetMetrics() sources.SourceMetrics {
+	if s.metrics == nil {
+		// Return empty metrics if not initialized, though NewPulsarSource should do it.
+		return *sources.NewSourceMetrics("pulsar_uninitialized")
+	}
+	return *s.metrics
+}
+
+// HealthCheck performs a health check on the Pulsar source.
+// This could involve checking the connection to the Pulsar broker.
+func (s *PulsarSource) HealthCheck() error {
+	// A simple health check could be trying to receive with a very short timeout,
+	// or checking client/consumer internal state if available.
+	// For now, we assume if Open succeeded, it's healthy.
+	// A more robust check might involve a ping to the service or checking consumer status.
+	if s.client == nil || s.consumer == nil {
+		return fmt.Errorf("pulsar source is not open or not healthy")
+	}
+	// Potentially, one could try a non-blocking receive or check some internal status.
+	// This is a basic check.
+	return nil
+}
+// Ensure PulsarSource implements the sources.Source interface
+var _ sources.Source = (*PulsarSource)(nil)


### PR DESCRIPTION
This commit introduces the basic structure for integrating Apache Pulsar as a data source.

- Defines the core `Source` interface and related structs (`Record`, `Offset`, `Schema`, `SourceConfig`) in `sources/api.go`.
- Implements the initial `PulsarSource` and `PulsarConfig` in `sources/pulsar/source.go`, including methods for Open, Read, CommitOffset, Close, and others. Placeholder implementations are included for auth, schema handling, and full offset management.
- Creates `sources/factory.go` with a `SourceFactory` to register and create source instances. Includes a placeholder wrapper for Pulsar source creation and stubs for other future sources.

This lays the groundwork for a fully functional Pulsar source connector.