### PR TITLE
docs: rewrite stale top-level docs to match post-rewrite architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,376 +1,99 @@
-# Wire Agents and Tools Documentation
+# AGENTS.md
 
-## Overview
+A navigation guide for AI agents and new contributors working in this repository.
 
-Wire is a real-time data streaming platform designed for efficient data ingestion, transformation, and distribution. It provides a modular architecture with various agents and tools that work together to create powerful data pipelines.
+> **Status note:** An earlier version of this file described a pre-rewrite, pipeline-based architecture with many built-in connectors. That architecture no longer exists. The codebase was fully rewritten (merged March 2026, PR [#148](https://github.com/tarungka/wire/pull/148)). This file reflects the current layout.
 
-### Core Architecture
-- **Pipeline-based processing** with configurable sources and sinks
-- **Distributed architecture** with clustering support
-- **Multi-protocol support** for various data sources and destinations
-- **Real-time data transformation** capabilities
+## What Wire is
 
-## Main Executable
+Wire is a distributed stream processing engine: a Master–Worker system that runs streaming jobs with exactly-once semantics, embedded state (PebbleDB), and Asynchronous Barrier Snapshot checkpointing. Read [`docs/vision.md`](docs/vision.md) first for goals and non-goals, then [`docs/architecture.md`](docs/architecture.md) for the runtime topology.
 
-### Wire CLI (`cmd/wire/main.go`)
-The main entry point for the Wire application. Handles initialization, configuration loading, and service orchestration.
+## Repository layout
 
-**Key responsibilities:**
-- Configuration management
-- Service initialization (HTTP, Cluster, Store)
-- Pipeline lifecycle management
-- Graceful shutdown handling
+```
+cmd/                     Single binary entry point (runs as coordinator or worker)
+  main.go                Mode selection (runCoordinator / runWorker)
+  init.go                CLI flag parsing
+  signals.go             Signal handling
 
-**Usage:**
+internal/
+  cmd/                   Build metadata (version/commit/branch)
+  config/                Config loading, validation, flag merging
+  coordinator/           Control plane: job manager, scheduler, checkpoint
+                         coordinator, HTTP API, leader election, Pebble
+                         metadata store, recovery
+  engine/                Stream processing engine: operators, barriers,
+                         checkpoint coordination, state backends, DLQ,
+                         watermarks, windowing
+  keygroup/              Key-group assignment (state sharding primitive)
+  logger/                zerolog wrappers
+  protocol/              Wire protocol framing and message types (msgpack)
+  rpc/                   Coordinator ↔ Worker RPC implementations
+  transport/             TCP transport (Yamux multiplexing)
+  worker/                Data plane: task slot management, registration,
+                         heartbeats, RPC client
+
+sdk/                     User-facing Go SDK: DataStream API, Source/Sink
+                         interfaces, environments, test harness
+
+docs/                    Canon design docs + WIP/TRD proposals
+```
+
+## Core interfaces
+
+- **`sdk.Source`** (`sdk/source.go`): `Open`, `ReadBatch`, `Close`, `GenerateWatermark`.
+- **`sdk.Sink`** (`sdk/sink.go`): `Open`, `Write`, `Close`.
+- No reference connector implementations ship yet. Design for reference connectors and a connector SDK is under [WIP-16](docs/trds/WIP-16/README.md).
+
+## Configuration
+
+Wire loads a YAML/JSON config file (default: `.config/config.json`) and applies CLI flag overrides. See [`internal/config/`](internal/config/) for the types. A formal schema is being defined in [WIP-13](docs/trds/WIP-13/README.md).
+
+## Build, run, test
+
 ```bash
-wire [flags]
+make build      # build the wire binary
+make test       # full test suite
+make unittest   # unit tests only
+make lint       # golangci-lint
+make format     # gofmt
 ```
 
-## Core Services
+Run modes (see [`docs/usage.md`](docs/usage.md) for the full flag reference):
 
-### HTTP Service (`internal/service/http/`)
-REST API and web interface for Wire management and monitoring.
-
-**Endpoints:**
-- Pipeline management (CRUD operations)
-- Health checks and metrics
-- Configuration management
-- Real-time monitoring
-
-**Key files:**
-- `server.go` - HTTP server implementation
-- `handlers/` - Request handlers for various endpoints
-- `middleware/` - Authentication, logging, and other middleware
-
-### Cluster Service (`internal/service/cluster/`)
-Distributed coordination service for multi-node Wire deployments.
-
-**Features:**
-- Node discovery and registration
-- Leader election
-- Distributed configuration sync
-- Health monitoring across nodes
-
-**Key components:**
-- Cluster manager
-- Node registry
-- Consensus protocol implementation
-
-### Store Service (`internal/service/store/`)
-Persistence layer abstraction for Wire's data and metadata.
-
-**Supported backends:**
-- SQLite (default for development)
-- PostgreSQL (recommended for production)
-- MySQL
-
-**Key interfaces:**
-- `Store` - Main storage interface
-- `Transaction` - Transactional operations
-- `Migration` - Database schema management
-
-## Pipeline Architecture
-
-### Pipeline Manager (`internal/pipeline/`)
-Core component managing data flow from sources to sinks.
-
-**Components:**
-- **Pipeline** - Main orchestrator for data flow
-- **Worker Pool** - Concurrent processing of data
-- **Transformer** - Data transformation logic
-- **Router** - Intelligent data routing between components
-
-**Pipeline lifecycle:**
-1. Configuration parsing
-2. Source initialization
-3. Sink preparation
-4. Worker pool creation
-5. Data flow orchestration
-6. Graceful shutdown
-
-## Data Connectors
-
-### Sources (`internal/sources/`)
-Input connectors for data ingestion.
-
-#### Available Sources:
-- **FileWatch** - Monitor files for changes
-  - Supports multiple file patterns
-  - Configurable polling intervals
-  - File rotation handling
-
-- **HTTP** - REST API endpoint for data ingestion
-  - Webhook support
-  - Authentication options
-  - Request validation
-
-- **Kafka** - Apache Kafka consumer
-  - Topic subscription
-  - Consumer group management
-  - Offset management
-
-- **RabbitMQ** - AMQP message queue consumer
-  - Queue binding
-  - Exchange configuration
-  - Message acknowledgment
-
-- **SQS** - AWS Simple Queue Service
-  - Long polling support
-  - Dead letter queue handling
-  - Batch processing
-
-- **Webhook** - Incoming webhook receiver
-  - Custom endpoint configuration
-  - Request authentication
-  - Payload validation
-
-### Sinks (`internal/sinks/`)
-Output connectors for data distribution.
-
-#### Available Sinks:
-- **Elasticsearch** - Search and analytics engine
-  - Index management
-  - Bulk operations
-  - Document mapping
-
-- **File** - File system writer
-  - Rotation policies
-  - Compression options
-  - Custom formatting
-
-- **HTTP** - REST API caller
-  - Retry logic
-  - Authentication
-  - Request batching
-
-- **Kafka** - Apache Kafka producer
-  - Topic routing
-  - Partitioning strategies
-  - Compression
-
-- **MongoDB** - NoSQL database
-  - Collection management
-  - Bulk operations
-  - Index creation
-
-- **PostgreSQL** - Relational database
-  - Table management
-  - Batch inserts
-  - Transaction support
-
-- **Redis** - In-memory data store
-  - Key patterns
-  - TTL management
-  - Pub/sub support
-
-- **S3** - AWS S3 object storage
-  - Bucket management
-  - Multipart uploads
-  - Object tagging
-
-- **Webhook** - Outgoing webhook sender
-  - Custom headers
-  - Retry policies
-  - Response handling
-
-## Network Components
-
-### TCP Multiplexing (`internal/pkg/mux/`)
-Efficient network communication layer.
-
-**Features:**
-- Connection pooling
-- Stream multiplexing
-- Protocol negotiation
-- Compression support
-
-### Transport Layer (`internal/pkg/transport/`)
-Abstraction for various transport protocols.
-
-**Supported protocols:**
-- TCP
-- HTTP/HTTPS
-- WebSocket
-- gRPC
-
-## Key Interfaces
-
-### Pipeline Interface
-```go
-type Pipeline interface {
-    Start(ctx context.Context) error
-    Stop() error
-    GetStatus() Status
-    GetMetrics() Metrics
-}
-```
-
-### Source Interface
-```go
-type Source interface {
-    Connect() error
-    Read() (<-chan Message, error)
-    Close() error
-}
-```
-
-### Sink Interface
-```go
-type Sink interface {
-    Connect() error
-    Write(messages []Message) error
-    Close() error
-}
-```
-
-### Store Interface
-```go
-type Store interface {
-    Get(key string) ([]byte, error)
-    Put(key string, value []byte) error
-    Delete(key string) error
-    Transaction(fn func(tx Transaction) error) error
-}
-```
-
-## Background Processes
-
-### Health Monitor
-- Periodic health checks for all components
-- Automatic recovery attempts
-- Alert generation
-
-### Metrics Collector
-- Performance metrics gathering
-- Resource utilization tracking
-- Custom metric support
-
-### Configuration Watcher
-- Dynamic configuration updates
-- Hot reload support
-- Validation before applying changes
-
-## Usage Examples
-
-### Creating a Simple Pipeline
-```yaml
-name: "file-to-elasticsearch"
-source:
-  type: "filewatch"
-  config:
-    path: "/var/log/app.log"
-    pattern: "*.log"
-sink:
-  type: "elasticsearch"
-  config:
-    url: "http://localhost:9200"
-    index: "app-logs"
-```
-
-### Multi-Source Pipeline
-```yaml
-name: "multi-source-aggregator"
-sources:
-  - type: "kafka"
-    config:
-      brokers: ["localhost:9092"]
-      topic: "events"
-  - type: "http"
-    config:
-      port: 8080
-      path: "/ingest"
-sinks:
-  - type: "postgresql"
-    config:
-      connection: "postgres://user:pass@localhost/db"
-      table: "events"
-  - type: "s3"
-    config:
-      bucket: "data-archive"
-      region: "us-east-1"
-```
-
-### Cluster Configuration
-```yaml
-cluster:
-  enabled: true
-  node_id: "node-1"
-  listen_address: ":7946"
-  peers:
-    - "node-2:7946"
-    - "node-3:7946"
-```
-
-## Development Guidelines
-
-### Adding New Sources/Sinks
-1. Implement the appropriate interface (`Source` or `Sink`)
-2. Add configuration struct with validation
-3. Register with the factory
-4. Add documentation and examples
-5. Write comprehensive tests
-
-### Testing Components
-- Unit tests for individual components
-- Integration tests for end-to-end flows
-- Performance benchmarks for critical paths
-- Chaos testing for distributed scenarios
-
-### Debugging Tools
-- Detailed logging with configurable levels
-- Metrics exposition for monitoring
-- Debug endpoints for component inspection
-- Trace propagation for distributed debugging
-
-## Best Practices
-
-1. **Configuration Management**
-   - Use environment variables for sensitive data
-   - Validate all configuration before applying
-   - Provide sensible defaults
-
-2. **Error Handling**
-   - Implement retry logic with backoff
-   - Log errors with context
-   - Fail fast for unrecoverable errors
-
-3. **Performance Optimization**
-   - Use connection pooling
-   - Implement batching where applicable
-   - Monitor resource usage
-
-4. **Security**
-   - Encrypt data in transit
-   - Use secure credential storage
-   - Implement proper authentication/authorization
-
-## Troubleshooting
-
-### Common Issues
-1. **Pipeline not starting**: Check configuration validity and source/sink connectivity
-2. **Data loss**: Verify acknowledgment settings and retry policies
-3. **Performance degradation**: Monitor metrics and adjust worker pool sizes
-4. **Cluster split-brain**: Check network connectivity between nodes
-
-### Debug Commands
 ```bash
-# Check pipeline status
-curl http://localhost:8080/api/pipelines
+./wire --mode coordinator --http-listen :4001 --listen :4002 \
+       --election-backend noop --coordinator-data-dir data/coordinator
 
-# View cluster members
-curl http://localhost:8080/api/cluster/members
-
-# Export metrics
-curl http://localhost:8080/metrics
+./wire --mode worker --coordinator-addr localhost:4002 --task-slots 4
 ```
 
-## Contributing
+## Making changes
 
-When adding new agents or tools:
-1. Follow the existing code structure
-2. Include comprehensive documentation
-3. Add unit and integration tests
-4. Update this AGENTS.md file
-5. Submit PR with clear description
+- **Bug fixes and small refactors:** open a PR directly.
+- **New subsystems, public interfaces, connectors, or changes to the execution model:** write a WIP under [`docs/trds/`](docs/trds/README.md) first. The WIP lifecycle is `Draft → In Review → Approved → Implemented`.
+- **Stale or conflicting documentation:** see [`docs/docs-todo.md`](docs/docs-todo.md) for the tracked gap list.
 
-For more information, see the main project documentation and contribution guidelines.
+## Canon doc map
+
+| Topic | Doc |
+|-------|-----|
+| Vision, principles | [`docs/vision.md`](docs/vision.md) |
+| Runtime topology, RPC surface | [`docs/architecture.md`](docs/architecture.md) |
+| Event time, checkpointing, backpressure | [`docs/execution-model.md`](docs/execution-model.md) |
+| State, Pebble, snapshots | [`docs/state-backend.md`](docs/state-backend.md) |
+| Deployment and operations | [`docs/operations.md`](docs/operations.md) |
+| CLI flags and getting started | [`docs/usage.md`](docs/usage.md) |
+| Glossary (Barrier, Key Group, Epoch, …) | [`docs/glossary.md`](docs/glossary.md) |
+| Active design proposals | [`docs/trds/`](docs/trds/) |
+
+## What is intentionally *not* in Wire (yet)
+
+These are mentioned in some older notes but are not in the codebase today:
+
+- Built-in connectors (Kafka, MongoDB, Elasticsearch, Redis, S3, etc.) — deleted in the rewrite; reintroduction is scoped under [WIP-16](docs/trds/WIP-16/README.md).
+- Raft consensus — replaced with PebbleDB + pluggable leader election ([WIP-09](docs/trds/WIP-09/README.md)). Raft is kept as a deferred option (Phase D).
+- YAML pipeline DSL — proposed in [WIP-19](docs/trds/WIP-19/README.md); not yet implemented.
+- SQL interface, Web UI, Helm charts, Kubernetes operator — not on the near-term roadmap.
+
+When in doubt, trust the code under `internal/` over any older documentation.

--- a/README.md
+++ b/README.md
@@ -1,145 +1,66 @@
 # Wire
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/go-%3E%3D1.21-blue.svg)](go.mod)
+[![Go Version](https://img.shields.io/badge/go-%3E%3D1.24-blue.svg)](go.mod)
 
-Wire is a high-performance, distributed stream processing framework designed for real-time data ingestion, transformation, and distribution. Built with Go, it provides a modular architecture with extensive connector support and powerful processing capabilities.
+Wire is a distributed stream processing engine written in Go. It targets unbounded data streams with strict correctness guarantees: exactly-once semantics, deterministic recovery, and strict event ordering. State lives in an embedded PebbleDB; checkpoints use Asynchronous Barrier Snapshots (Chandy–Lamport). Wire is designed to run as a single binary with no external dependencies.
 
-## What Wire Does
-
-Wire helps you:
-- Move data between different systems
-- Transform data as it flows
-- Handle large amounts of data efficiently
-- Set up data pipelines with simple configuration files
+> **Project status:** pre-`v0.1.0`, alpha. The codebase underwent a full architectural rewrite (merged March 2026, PR [#148](https://github.com/tarungka/wire/pull/148)). The engine, coordinator, and worker are in place; user-facing surfaces (configuration reference, Go SDK, REST API, connector SDK) are actively being specified under the [WIP process](docs/trds/). There are no built-in connectors yet.
 
 ## Documentation
 
-For detailed documentation, check out:
-- **[Technical Documentation](docs/)** - Architecture, design, and roadmaps
-- **[AGENTS.md](AGENTS.md)** - Detailed component reference
-- **[CONTRIBUTING.md](CONTRIBUTING.md)** - How to contribute
+The canonical design docs live in [`docs/`](docs/):
 
-## Quick Start
+| Doc | Purpose |
+|-----|---------|
+| [`docs/vision.md`](docs/vision.md) | Goals, non-goals, and design principles |
+| [`docs/architecture.md`](docs/architecture.md) | Runtime topology, control plane, data plane |
+| [`docs/execution-model.md`](docs/execution-model.md) | Event/time/watermarks, checkpointing, backpressure |
+| [`docs/state-backend.md`](docs/state-backend.md) | Pebble integration, snapshot protocol |
+| [`docs/operations.md`](docs/operations.md) | Deployment modes, scaling, monitoring |
+| [`docs/usage.md`](docs/usage.md) | Build/run instructions and CLI flag reference |
+| [`docs/trds/`](docs/trds/) | Wire Improvement Proposals (WIPs) — design history and in-flight proposals |
 
-### Installation
+For a gap analysis against the current codebase, see [`docs/docs-todo.md`](docs/docs-todo.md). For the project roadmap, see [`ROADMAP.md`](ROADMAP.md).
 
-The easiest way to get started:
+## Build
 
 ```bash
-# Using Go
-go install github.com/wire/wire/cmd/wire@latest
-
-# Or clone and build
-git clone https://github.com/wire/wire.git
+git clone https://github.com/tarungka/wire.git
 cd wire
-go build -o wire cmd/wire/main.go
-```
-
-### Your First Pipeline
-
-1. Create a file called `pipeline.yaml`:
-
-```yaml
-name: "my-first-pipeline"
-source:
-  type: "file"
-  config:
-    path: "/path/to/input.txt"
-sink:
-  type: "file"
-  config:
-    path: "/path/to/output.txt"
-```
-
-2. Run Wire:
-
-```bash
-./wire --config pipeline.yaml
-```
-
-That's it! Wire will read from `input.txt` and write to `output.txt`.
-
-## Available Connectors
-
-### Sources (Where data comes from)
-- **file** - Read from files
-- **http** - Receive data via HTTP
-- **kafka** - Read from Kafka topics
-- **mongodb** - Read from MongoDB
-- **rabbitmq** - Read from RabbitMQ
-- **sqs** - Read from AWS SQS
-- **webhook** - Receive webhooks
-
-### Sinks (Where data goes to)
-- **file** - Write to files
-- **http** - Send via HTTP
-- **kafka** - Write to Kafka
-- **elasticsearch** - Send to Elasticsearch
-- **mongodb** - Write to MongoDB
-- **postgresql** - Write to PostgreSQL
-- **redis** - Write to Redis
-- **s3** - Upload to AWS S3
-- **webhook** - Send webhooks
-
-## More Examples
-
-### Reading from HTTP and writing to a database:
-
-```yaml
-name: "http-to-database"
-source:
-  type: "http"
-  config:
-    port: 8080
-    path: "/data"
-sink:
-  type: "postgresql"
-  config:
-    connection: "postgres://user:pass@localhost/mydb"
-    table: "events"
-```
-
-### Reading from Kafka and writing to S3:
-
-```yaml
-name: "kafka-to-s3"
-source:
-  type: "kafka"
-  config:
-    brokers: ["localhost:9092"]
-    topic: "events"
-sink:
-  type: "s3"
-  config:
-    bucket: "my-bucket"
-    region: "us-east-1"
-```
-
-## Development
-
-To work on Wire:
-
-```bash
-# Get dependencies
-go mod download
-
-# Run tests
-make test
-
-# Build
 make build
+```
+
+This produces the `wire` binary in the project root. Go 1.24+ is required.
+
+## Run
+
+Wire runs as a single binary in either coordinator or worker mode. See [`docs/usage.md`](docs/usage.md) for the full flag reference.
+
+**Coordinator (single-node):**
+
+```bash
+./wire \
+  --mode coordinator \
+  --http-listen :4001 \
+  --listen :4002 \
+  --election-backend noop \
+  --coordinator-data-dir data/coordinator
+```
+
+**Worker:**
+
+```bash
+./wire \
+  --mode worker \
+  --coordinator-addr localhost:4002 \
+  --task-slots 4
 ```
 
 ## Contributing
 
-We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for development setup and contribution guidelines. Non-trivial changes should go through the [WIP process](docs/trds/README.md).
 
 ## License
 
-Wire is licensed under the MIT License. See [LICENSE](LICENSE) for details.
-
-## Community
-
-- **Issues**: [Report bugs or request features](https://github.com/wire/wire/issues)
-- **Discussions**: [Ask questions and share ideas](https://github.com/wire/wire/discussions)
+MIT — see [`LICENSE`](LICENSE).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,232 +1,59 @@
-# Wire Project Roadmap
+# Wire Roadmap
 
-## Project Vision
-Wire aims to be the go-to distributed stream processing framework for building reliable, scalable, and performant real-time data pipelines with strong consistency guarantees.
+> **Status note:** An earlier version of this file listed dated quarterly milestones (Q1–Q4 2025) and features from a pre-rewrite architecture (Raft, BadgerDB, MongoDB/Kafka/Elasticsearch connectors). Those milestones never landed and the architecture that would have carried them no longer exists. The codebase was fully rewritten (merged March 2026, PR [#148](https://github.com/tarungka/wire/pull/148)). This file now tracks real, in-flight work.
+>
+> Individual proposals (and all design decisions) live under [`docs/trds/`](docs/trds/). This file is only a shortcut view.
 
----
+## Current state
 
-## 🎯 Current State (v0.1.0-alpha)
+- Pre-`v0.1.0`, alpha.
+- Coordinator (control plane), Worker (data plane), engine, state backend, and checkpoint coordinator are implemented.
+- User-facing surfaces (config schema, Go SDK, REST API, connector SDK, security model) are being specified via Wire Improvement Proposals (WIPs) before implementation.
+- There are no built-in connectors yet.
 
-### ✅ Completed Features
-- [x] Core Raft consensus implementation with multi-database backend support
-- [x] Basic pipeline architecture with source/sink abstractions
-- [x] HTTP API with Gin framework
-- [x] Support for MongoDB and Kafka sources
-- [x] Support for Elasticsearch, Kafka, and File sinks
-- [x] Job-based processing model with UUID v7
-- [x] TCP multiplexing for inter-node communication
-- [x] Basic cluster management (join, leave, status)
-- [x] Comprehensive technical documentation
+## In-flight WIPs
 
-### 🚧 In Progress
-- [ ] Complete FSM snapshot/restore functionality
-- [ ] TLS/mTLS support for secure communication
-- [ ] Pipeline state persistence
+The full index lives in [`docs/trds/README.md`](docs/trds/README.md). Status reflects the state of each WIP at the time of writing; read the WIP itself for the latest.
 
----
+| WIP | Topic | Status |
+|-----|-------|--------|
+| [WIP-01](docs/trds/WIP-01/README.md) | Wire Protocol & Serialization Format | Draft |
+| [WIP-02](docs/trds/WIP-02/README.md) | Goroutine & Concurrency Model | Draft |
+| [WIP-03](docs/trds/WIP-03/README.md) | Key Group Assignment & State Sharding | Draft |
+| [WIP-04](docs/trds/WIP-04/README.md) | Watermark Generation Algorithm | Draft |
+| [WIP-05](docs/trds/WIP-05/README.md) | Barrier Alignment Timeout & Failure Handling | Draft |
+| [WIP-06](docs/trds/WIP-06/README.md) | Checkpoint Metadata Schema | Draft |
+| [WIP-07](docs/trds/WIP-07/README.md) | RPC Interface Specification | Draft |
+| [WIP-08](docs/trds/WIP-08/README.md) | Heartbeat & Health Monitoring | Draft |
+| [WIP-09](docs/trds/WIP-09/README.md) | Coordinator High Availability | Draft |
+| [WIP-10](docs/trds/WIP-10/README.md) | Two-Phase Commit for Transactional Sinks | Draft |
+| [WIP-11](docs/trds/WIP-11/README.md) | Error Handling & Dead Letter Queues | Draft |
+| [WIP-12](docs/trds/WIP-12/README.md) | Late Data & Allowed Lateness | Draft |
+| [WIP-13](docs/trds/WIP-13/README.md) | Configuration Reference | Draft |
+| [WIP-14](docs/trds/WIP-14/README.md) | User API & Go SDK | Draft |
+| [WIP-15](docs/trds/WIP-15/README.md) | Job Lifecycle & REST API | Draft |
+| [WIP-16](docs/trds/WIP-16/README.md) | Connector SDK & Built-in Connectors | Draft |
+| [WIP-17](docs/trds/WIP-17/README.md) | Security Model | Draft |
+| [WIP-18](docs/trds/WIP-18/README.md) | Multiple State Backends | Draft |
+| [WIP-19](docs/trds/WIP-19/README.md) | YAML Pipeline Parser | Proposed |
+| [WIP-20](docs/trds/WIP-20/README.md) | Task Execution Engine | Draft |
 
-## 📅 Q1 2025: Foundation & Stability (v0.2.0)
+## Near-term focus (in priority order)
 
-### Core Infrastructure
-- [ ] **Complete Snapshot/Restore Implementation**
-  - Implement full FSM snapshot functionality
-  - Add snapshot scheduling and retention policies
-  - Optimize snapshot performance for large datasets
+These are the items most worth tackling before a `v0.1.0` release. They are intentionally short-term and pragmatic — each unblocks either contributors or end users.
 
-- [ ] **Security Enhancements**
-  - Complete TLS/mTLS implementation for all communication
-  - Add authentication and authorization framework
-  - Implement API key management
-  - Add role-based access control (RBAC)
+1. **Finish the four coordinator TODOs** that block end-to-end fault tolerance and rescaling:
+   - Pebble state backend wiring (`internal/engine/state_backend_factory.go`, [WIP-18](docs/trds/WIP-18/README.md))
+   - Savepoint restore (`internal/coordinator/job_manager.go`)
+   - Barrier injection via RPC (`internal/coordinator/savepoint_manager.go`)
+   - Task rescheduling on worker removal (`internal/coordinator/http_cluster.go`)
 
-- [ ] **Observability & Monitoring**
-  - Integrate OpenTelemetry for distributed tracing
-  - Add Prometheus metrics export
-  - Implement structured logging with log levels
-  - Create health check endpoints with detailed status
+2. **Promote WIP-13, WIP-14, WIP-15, WIP-16 from Draft to Approved.** These are the user-facing surfaces (config, SDK, REST API, connector SDK) that unblock anyone actually running Wire.
 
-### Pipeline Improvements
-- [ ] **Pipeline State Management**
-  - Persist pipeline configurations in Raft store
-  - Implement pipeline versioning
-  - Add pipeline pause/resume functionality
-  - Support pipeline hot-reloading
+3. **Ship a reference source/sink pair** (e.g. stdin source, file sink) as the first in-tree connector. Smallest change that makes Wire runnable end-to-end, and validates the `Source`/`Sink` interfaces in [`sdk/`](sdk/) against real code.
 
-- [ ] **Error Handling & Recovery**
-  - Implement dead letter queues
-  - Add retry mechanisms with exponential backoff
-  - Create error reporting and alerting hooks
-  - Support partial pipeline failures
+4. **Close P1 gaps in [`docs/docs-todo.md`](docs/docs-todo.md):** RPC spec, wire protocol spec, 2PC for transactional sinks, security model. All have corresponding WIPs.
 
----
+## How to propose new work
 
-## 📅 Q2 2025: Scale & Performance (v0.3.0)
-
-### Performance Optimizations
-- [ ] **Processing Enhancements**
-  - Implement adaptive batching
-  - Add backpressure handling
-  - Optimize memory usage with object pooling
-  - Support pipeline parallelism configuration
-
-- [ ] **Storage Optimizations**
-  - Implement data compression for Raft logs
-  - Add compaction strategies for different backends
-  - Optimize BadgerDB settings for production
-  - Support tiered storage
-
-### Scalability Features
-- [ ] **Dynamic Cluster Management**
-  - Implement auto-scaling based on load
-  - Add node health monitoring and auto-recovery
-  - Support rolling upgrades
-  - Implement load balancing for pipeline distribution
-
-- [ ] **Multi-Region Support**
-  - Add geo-replication capabilities
-  - Implement region-aware data routing
-  - Support cross-region failover
-  - Add latency-based routing
-
----
-
-## 📅 Q3 2025: Enterprise Features (v0.4.0)
-
-### Advanced Processing
-- [ ] **Complex Event Processing (CEP)**
-  - Add windowing operations (tumbling, sliding, session)
-  - Implement event-time processing
-  - Support watermarks for late data handling
-  - Add stateful transformations
-
-- [ ] **SQL Interface**
-  - Implement SQL parser for pipeline definitions
-  - Add SQL-based transformations
-  - Support JOIN operations across streams
-  - Create materialized views
-
-### Enterprise Integration
-- [ ] **Additional Sources/Sinks**
-  - Apache Pulsar source/sink
-  - RabbitMQ source/sink
-  - AWS Kinesis source/sink
-  - Google Pub/Sub source/sink
-  - PostgreSQL CDC source
-  - S3/GCS/Azure Blob sinks
-
-- [ ] **Schema Management**
-  - Add schema registry integration
-  - Implement schema evolution support
-  - Support Avro, Protobuf, and JSON Schema
-  - Add data validation framework
-
----
-
-## 📅 Q4 2025: Production Ready (v1.0.0)
-
-### Production Features
-- [ ] **Operations & Maintenance**
-  - Implement backup and restore tools
-  - Add disaster recovery procedures
-  - Create operation runbooks
-  - Support zero-downtime migrations
-
-- [ ] **Performance Guarantees**
-  - Implement exactly-once processing semantics
-  - Add SLA monitoring and reporting
-  - Support throughput guarantees
-  - Implement adaptive performance tuning
-
-### Ecosystem & Tools
-- [ ] **Developer Experience**
-  - Create Wire CLI for cluster management
-  - Add Visual Pipeline Designer (Web UI)
-  - Implement pipeline testing framework
-  - Create pipeline templates library
-
-- [ ] **Integration & Extensions**
-  - Develop Kubernetes operator
-  - Create Helm charts
-  - Add Terraform provider
-  - Implement plugin system for custom sources/sinks
-
----
-
-## 🚀 Future Vision (v2.0.0+)
-
-### Advanced Features
-- [ ] **Machine Learning Integration**
-  - Support for ML model serving in pipelines
-  - Real-time feature engineering
-  - A/B testing framework
-  - Model performance monitoring
-
-- [ ] **Advanced Analytics**
-  - Real-time analytics dashboard
-  - Anomaly detection capabilities
-  - Predictive analytics support
-  - Custom metrics and KPIs
-
-### Platform Evolution
-- [ ] **Wire Cloud**
-  - Managed Wire service
-  - Multi-tenancy support
-  - Usage-based billing
-  - Global deployment options
-
-- [ ] **Wire Studio**
-  - Visual development environment
-  - Drag-and-drop pipeline builder
-  - Real-time debugging tools
-  - Performance profiler
-
----
-
-## 📊 Success Metrics
-
-### Technical Metrics
-- **Performance**: 100k+ messages/second per node
-- **Latency**: < 10ms p99 end-to-end
-- **Availability**: 99.99% uptime
-- **Scalability**: Support 100+ node clusters
-
-### Community Metrics
-- **Adoption**: 1000+ production deployments
-- **Contributors**: 50+ active contributors
-- **Ecosystem**: 20+ community plugins
-- **Documentation**: Comprehensive guides and tutorials
-
----
-
-## 🤝 How to Contribute
-
-1. **Code Contributions**
-   - Check open issues labeled "good first issue"
-   - Follow contribution guidelines
-   - Write tests for new features
-   - Update documentation
-
-2. **Non-Code Contributions**
-   - Report bugs and feature requests
-   - Improve documentation
-   - Create tutorials and blog posts
-   - Help other users in discussions
-
-3. **Priority Areas**
-   - Security improvements
-   - Performance optimizations
-   - Additional source/sink connectors
-   - Documentation and examples
-
----
-
-## 📞 Get Involved
-
-- **GitHub**: [github.com/tarungka/wire](https://github.com/tarungka/wire)
-- **Discussions**: GitHub Discussions for Q&A
-- **Issues**: Report bugs and request features
-- **Pull Requests**: Contribute code and documentation
-
----
-
-*This roadmap is subject to change based on community feedback and project priorities. Last updated: January 2025*
+See [`docs/trds/README.md`](docs/trds/README.md) for the WIP process. Small changes do not need a WIP; anything that touches public surfaces, the execution model, or multiple modules does.


### PR DESCRIPTION
README.md, AGENTS.md, and ROADMAP.md all described the pre-rewrite, pipeline-based architecture: Raft consensus, BadgerDB, built-in Kafka/ MongoDB/Elasticsearch connectors, dated Q1-Q4 2025 milestones. None of that exists in the codebase since the architectural rewrite in PR #148.

Rewrite all three to reflect the current reality:
- Coordinator/Worker topology, PebbleDB state, ABS checkpointing
- Single binary with --mode coordinator | worker
- No built-in connectors yet; Source/Sink interfaces exist in sdk/ but have no in-tree reference implementations
- Point to canon docs in docs/ and the WIP/TRD process for planning, rather than inventing fake quarterly deadlines

Also fix the module path in README.md (github.com/wire/wire -> github.com/tarungka/wire) and the Go version requirement (1.21 -> 1.24 to match go.mod).