### PR TITLE
feat(worker): execute operators end-to-end via registry + task executor

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,74 @@
+# Wire examples
+
+Two small programs that show how the Phase 1 worker/SDK split works in
+practice.
+
+| Program | Purpose |
+|---------|---------|
+| [`wire-worker-example`](wire-worker-example/) | A custom worker binary that registers operators and connects to a coordinator. |
+| [`submit-uppercase-job`](submit-uppercase-job/) | An SDK client that builds a `Source → Map → Sink` graph and submits it in Cluster mode. |
+
+The architectural split is deliberate: user-defined functions can't be
+serialized across an RPC boundary, so workers run a binary that imports
+the user's UDFs and registers them by name (see
+[WIP-16](../docs/trds/WIP-16/README.md)).
+
+## End-to-end smoke test
+
+This walkthrough boots one coordinator and one worker on the same machine,
+then submits a job. All three commands run in separate terminals.
+
+### Terminal 1 — coordinator
+
+```bash
+make build
+./wire \
+    --mode coordinator \
+    --http-listen 127.0.0.1:4001 \
+    --listen 127.0.0.1:4002 \
+    --election-backend noop \
+    --coordinator-data-dir data/coordinator
+```
+
+### Terminal 2 — worker
+
+```bash
+go run ./examples/wire-worker-example \
+    --coordinator-addr 127.0.0.1:4002 \
+    --task-slots 4
+```
+
+You should see the worker register and start the heartbeat loop.
+
+### Terminal 3 — submit a job
+
+```bash
+go run ./examples/submit-uppercase-job \
+    --coordinator-url http://127.0.0.1:4001 \
+    --message hello --message world --message wire
+```
+
+The submitter exits when the job reaches `FINISHED`. Check the worker's
+output for processing logs. You can also query the coordinator directly:
+
+```bash
+curl -s http://127.0.0.1:4001/api/v1/jobs | jq
+curl -s http://127.0.0.1:4001/api/v1/jobs/<job_id> | jq
+```
+
+## Cross-process output capture
+
+The `memory-sink` connector stores collected events in a package-level map
+inside the *worker* process — fine for the in-process integration test
+(`internal/worker/integration_test.go`) but not visible to a separate
+submitter binary. To assert sink output in a real distributed test, use a
+sink that writes to a shared store (file, S3, Postgres) and read it back
+from the test.
+
+## What about plain `curl`?
+
+You can submit a job with `curl`, but the request body needs a base64-encoded
+msgpack `JobGraph`. The submitter binary above uses the SDK to build that
+payload — the same encoder you would call from your own application code.
+For ad-hoc inspection, prefer the SDK path; the wire format is internal and
+will evolve as the WIPs land.

--- a/examples/submit-uppercase-job/main.go
+++ b/examples/submit-uppercase-job/main.go
@@ -1,0 +1,88 @@
+// submit-uppercase-job builds a Source -> Map(upper) -> Sink pipeline using
+// the SDK and submits it to a Wire coordinator in Cluster mode.
+//
+// It pairs with the wire-worker-example binary (which must be running and
+// connected to the same coordinator) and demonstrates the end-to-end
+// submission flow described in Phase 1 of the distributed-execution plan.
+//
+// Usage:
+//
+//	go run ./examples/submit-uppercase-job \
+//	    --coordinator-url http://127.0.0.1:4001 \
+//	    --message hello --message world --message wire
+//
+// The collected output is printed by the worker process; this binary just
+// reports the job's terminal status. (In a real test you would wire up a
+// sink that writes to a shared store rather than the in-process MemorySink.)
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/tarungka/wire/internal/protocol"
+	"github.com/tarungka/wire/sdk"
+	"github.com/tarungka/wire/sdk/connectors/memory"
+)
+
+type stringList []string
+
+func (s *stringList) String() string     { return strings.Join(*s, ",") }
+func (s *stringList) Set(v string) error { *s = append(*s, v); return nil }
+
+func main() {
+	var messages stringList
+	coordURL := flag.String("coordinator-url", "http://127.0.0.1:4001", "coordinator HTTP URL")
+	jobName := flag.String("name", "uppercase-demo", "job name")
+	sinkID := flag.String("sink-id", "uppercase-demo", "sink ID (worker-side memory.Collected key)")
+	flag.Var(&messages, "message", "an event the source will emit; repeatable")
+	flag.Parse()
+
+	if len(messages) == 0 {
+		messages = stringList{"hello", "world", "wire"}
+	}
+
+	srcCfg, err := protocol.EncodeMsgPack(memory.SourceConfig{Events: toBytes(messages)})
+	check(err)
+	sinkCfg, err := protocol.EncodeMsgPack(memory.SinkConfig{SinkID: *sinkID})
+	check(err)
+
+	env := sdk.New().
+		SetMode(sdk.Cluster).
+		SetCoordinator(*coordURL).
+		SetParallelism(1)
+
+	env.AddSourceNamed("src", "memory-source", srcCfg).
+		MapNamed("upper", "upper", nil).
+		AddSinkNamed("sink", "memory-sink", sinkCfg)
+
+	res, err := env.ExecuteWithName(context.Background(), *jobName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "execute: %v\n", err)
+		os.Exit(1)
+	}
+	if res.Err != nil {
+		fmt.Fprintf(os.Stderr, "job err: %v\n", res.Err)
+		os.Exit(1)
+	}
+	fmt.Printf("job %s finished in %s\n", res.JobID, res.Metrics.Duration)
+	fmt.Println("(captured events live inside the worker process; check its logs or use a real sink for cross-process output)")
+}
+
+func toBytes(ss []string) [][]byte {
+	out := make([][]byte, len(ss))
+	for i, s := range ss {
+		out[i] = []byte(s)
+	}
+	return out
+}
+
+func check(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/examples/wire-worker-example/main.go
+++ b/examples/wire-worker-example/main.go
@@ -21,9 +21,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/rs/zerolog"
-
 	"github.com/tarungka/wire/internal/engine"
+	"github.com/tarungka/wire/internal/logger"
 	"github.com/tarungka/wire/internal/worker"
 	"github.com/tarungka/wire/sdk/connectors/memory"
 )
@@ -37,9 +36,10 @@ func main() {
 	)
 	flag.Parse()
 
-	log := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).
-		Level(zerolog.InfoLevel).
-		With().Timestamp().Logger()
+	// Use the same logger configuration as the wire CLI so both processes
+	// produce identical output. We don't open a file — logger.GetLogger
+	// handles a nil log file gracefully (writes only to the console).
+	log := logger.GetLogger("worker-example")
 
 	// Register the operators this worker can run. In a real deployment,
 	// users add their own factories alongside (or instead of) these.

--- a/examples/wire-worker-example/main.go
+++ b/examples/wire-worker-example/main.go
@@ -1,0 +1,84 @@
+// wire-worker-example is a runnable demo of the operator-registry pattern.
+//
+// It registers the in-tree memory-source and memory-sink connectors plus a
+// trivial "upper" map operator, then runs as a Wire worker that connects to
+// a coordinator. Pair it with the submit-uppercase-job example (or any
+// SDK program in Cluster mode) to see end-to-end execution.
+//
+// Usage:
+//
+//	go run ./examples/wire-worker-example \
+//	    --coordinator-addr 127.0.0.1:4002 \
+//	    --task-slots 4
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/rs/zerolog"
+
+	"github.com/tarungka/wire/internal/engine"
+	"github.com/tarungka/wire/internal/worker"
+	"github.com/tarungka/wire/sdk/connectors/memory"
+)
+
+func main() {
+	var (
+		coordinatorAddr = flag.String("coordinator-addr", "127.0.0.1:4002", "coordinator wire-protocol address")
+		workerID        = flag.String("worker-id", "", "worker ID (defaults to hostname)")
+		listenAddr      = flag.String("listen", "127.0.0.1:0", "data-plane listen address (Phase 2+)")
+		taskSlots       = flag.Int("task-slots", 4, "number of concurrent task slots")
+	)
+	flag.Parse()
+
+	log := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).
+		Level(zerolog.InfoLevel).
+		With().Timestamp().Logger()
+
+	// Register the operators this worker can run. In a real deployment,
+	// users add their own factories alongside (or instead of) these.
+	worker.RegisterSource("memory-source", memory.SourceFactory())
+	worker.RegisterSink("memory-sink", memory.SinkFactory())
+	worker.RegisterMap("upper", upperMapFactory())
+
+	w := worker.New(worker.Config{
+		WorkerID:        *workerID,
+		CoordinatorAddr: *coordinatorAddr,
+		ListenAddr:      *listenAddr,
+		TaskSlots:       *taskSlots,
+	}, log)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	log.Info().Str("coordinator", *coordinatorAddr).Int("slots", *taskSlots).Msg("starting wire-worker-example")
+	if err := w.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "worker exited: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// upperMapFactory returns a MapFactory whose operator uppercases each event's value.
+func upperMapFactory() worker.MapFactory {
+	return func(_ context.Context, _ []byte, _ worker.TaskContext) (engine.MapOperator, error) {
+		return &upperMap{}, nil
+	}
+}
+
+type upperMap struct{}
+
+func (*upperMap) Open(_ context.Context) error        { return nil }
+func (*upperMap) Close() error                        { return nil }
+func (*upperMap) Checkpoint(_ uint64) ([]byte, error) { return nil, nil }
+func (*upperMap) Map(_ context.Context, e engine.Event) (engine.Event, error) {
+	e.Value = []byte(strings.ToUpper(string(e.Value)))
+	return e, nil
+}
+
+var _ engine.MapOperator = (*upperMap)(nil)

--- a/internal/coordinator/http_jobs.go
+++ b/internal/coordinator/http_jobs.go
@@ -1,26 +1,47 @@
 package coordinator
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 )
 
 // submitJobRequest is the JSON body for POST /api/v1/jobs.
+//
+// Exactly one of Config or GraphBytes should be populated:
+//   - GraphBytes: base64-encoded msgpack rpc.JobGraph (preferred; produced by
+//     the SDK's clusterExecutor). Persisted verbatim as the job's config
+//     bytes, then parsed by the scheduler to produce task descriptors.
+//   - Config: arbitrary opaque bytes (legacy path; ignored by the scheduler).
 type submitJobRequest struct {
 	Name        string `json:"name"`
 	Parallelism int    `json:"parallelism"`
-	Config      string `json:"config"`
+	Config      string `json:"config,omitempty"`
+	GraphBytes  string `json:"graph_bytes,omitempty"`
 }
 
 func (s *HTTPServer) handleSubmitJob(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MiB limit
+	r.Body = http.MaxBytesReader(w, r.Body, 4<<20) // 4 MiB limit
 	var req submitJobRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "invalid JSON body")
 		return
 	}
 
-	job, err := s.coord.SubmitJob(req.Name, req.Parallelism, []byte(req.Config))
+	var configBytes []byte
+	switch {
+	case req.GraphBytes != "":
+		decoded, err := base64.StdEncoding.DecodeString(req.GraphBytes)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "graph_bytes is not valid base64")
+			return
+		}
+		configBytes = decoded
+	case req.Config != "":
+		configBytes = []byte(req.Config)
+	}
+
+	job, err := s.coord.SubmitJob(req.Name, req.Parallelism, configBytes)
 	if err != nil {
 		writeJobError(w, err)
 		return

--- a/internal/coordinator/job_state_machine.go
+++ b/internal/coordinator/job_state_machine.go
@@ -6,8 +6,12 @@ import (
 )
 
 // validTransitions defines the set of legal job state transitions.
+//
+// JobCreated -> JobFailing is allowed for permanent pre-deployment failures
+// (e.g. malformed graph, missing operator factory) so the scheduler can move
+// such a job out of the queue immediately rather than retrying forever.
 var validTransitions = map[JobStatus][]JobStatus{
-	JobCreated:   {JobDeploying, JobCanceling},
+	JobCreated:   {JobDeploying, JobFailing, JobCanceling},
 	JobDeploying: {JobRunning, JobFailing, JobCanceling},
 	JobRunning:   {JobFinishing, JobPaused, JobFailing, JobCanceling},
 	JobPaused:    {JobDeploying},

--- a/internal/coordinator/rpc_handlers.go
+++ b/internal/coordinator/rpc_handlers.go
@@ -121,6 +121,28 @@ func (c *Coordinator) HandleUpdateTaskStatus(_ context.Context, _ uint64, payloa
 				c.log.Info().Str("job_id", req.JobID).Msg("task failed, job is FAILING")
 			}
 		}
+
+	case rpc.TaskStatusFinished:
+		c.mu.RLock()
+		allFinished := c.allTasksInStatus(req.JobID, rpc.TaskStatusFinished)
+		currentStatus := job.Status
+		c.mu.RUnlock()
+
+		// JobRunning → JobFinishing → JobFinished. The Finishing stage is a
+		// synchronous pass-through for Phase 1 since there is no coordinated
+		// flush/commit step yet; the 2PC sink path in Phase 4 will linger
+		// here until PreCommit/Commit acks arrive.
+		if allFinished && currentStatus == JobRunning {
+			if err := c.transitionJob(job, JobFinishing); err != nil {
+				c.log.Warn().Err(err).Str("job_id", req.JobID).Msg("failed to transition job to FINISHING")
+				break
+			}
+			if err := c.transitionJob(job, JobFinished); err != nil {
+				c.log.Warn().Err(err).Str("job_id", req.JobID).Msg("failed to transition job to FINISHED")
+			} else {
+				c.log.Info().Str("job_id", req.JobID).Msg("all tasks finished, job is FINISHED")
+			}
+		}
 	}
 
 	return &rpc.UpdateTaskStatusResponse{Accepted: true}, nil

--- a/internal/coordinator/scheduler.go
+++ b/internal/coordinator/scheduler.go
@@ -61,16 +61,17 @@ func (c *Coordinator) scheduleTick(ctx context.Context) {
 func (c *Coordinator) scheduleJob(job *JobMeta) {
 	tasks, err := generateTaskDescriptors(job)
 	if err != nil {
-		c.log.Error().Err(err).Str("job_id", job.ID).Msg("cannot generate task descriptors")
-		// Transition to Failing so the job doesn't retry forever with a broken graph.
-		c.mu.Lock()
-		if job.Status == JobCreated {
-			_ = ValidateTransition(job.Status, JobFailing)
-			job.Status = JobFailing
-			job.UpdatedAt = time.Now().UTC()
-			_ = c.persistJobLocked(job)
+		c.log.Error().Err(err).Str("job_id", job.ID).Msg("cannot generate task descriptors; failing job")
+		// Permanent failure (e.g. malformed graph from a legacy submission).
+		// Walk Created -> Failing -> Failed so the job ends in a terminal
+		// state and never re-enters the scheduler queue.
+		if terr := c.transitionJob(job, JobFailing); terr != nil {
+			c.log.Warn().Err(terr).Str("job_id", job.ID).Msg("could not transition to FAILING")
+			return
 		}
-		c.mu.Unlock()
+		if terr := c.transitionJob(job, JobFailed); terr != nil {
+			c.log.Warn().Err(terr).Str("job_id", job.ID).Msg("could not finalize FAILED transition")
+		}
 		return
 	}
 

--- a/internal/coordinator/scheduler.go
+++ b/internal/coordinator/scheduler.go
@@ -59,7 +59,20 @@ func (c *Coordinator) scheduleTick(ctx context.Context) {
 
 // scheduleJob attempts to schedule a single CREATED job.
 func (c *Coordinator) scheduleJob(job *JobMeta) {
-	tasks := generateTaskDescriptors(job)
+	tasks, err := generateTaskDescriptors(job)
+	if err != nil {
+		c.log.Error().Err(err).Str("job_id", job.ID).Msg("cannot generate task descriptors")
+		// Transition to Failing so the job doesn't retry forever with a broken graph.
+		c.mu.Lock()
+		if job.Status == JobCreated {
+			_ = ValidateTransition(job.Status, JobFailing)
+			job.Status = JobFailing
+			job.UpdatedAt = time.Now().UTC()
+			_ = c.persistJobLocked(job)
+		}
+		c.mu.Unlock()
+		return
+	}
 
 	assignments, err := c.assignTasks(tasks)
 	if err != nil {
@@ -151,9 +164,36 @@ func (c *Coordinator) scheduleJob(job *JobMeta) {
 		Msg("job scheduled")
 }
 
-// generateTaskDescriptors creates task descriptors for a job.
-// MVP: single implicit "pipeline" operator with parallelism tasks.
-func generateTaskDescriptors(job *JobMeta) []rpc.TaskDescriptor {
+// generateTaskDescriptors creates task descriptors for a job by decoding
+// the persisted JobGraph (stored verbatim as job.Config, msgpack-encoded)
+// and producing one descriptor per subtask.
+//
+// Phase 1: linear pipelines only. Every subtask carries the full operator
+// chain (topo-sorted from the graph). Cross-worker shuffle comes in Phase 2,
+// at which point this splits the graph at shuffle boundaries and populates
+// Upstream/Downstream channel info.
+func generateTaskDescriptors(job *JobMeta) ([]rpc.TaskDescriptor, error) {
+	if len(job.Config) == 0 {
+		return nil, fmt.Errorf("job %q has no graph (config is empty)", job.ID)
+	}
+
+	var graph rpc.JobGraph
+	if err := protocol.DecodeMsgPack(job.Config, &graph); err != nil {
+		return nil, fmt.Errorf("decode job graph: %w", err)
+	}
+
+	sorted, err := topoSortOperators(graph)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(sorted) == 0 {
+		return nil, fmt.Errorf("job %q has no operators", job.ID)
+	}
+	if hasShuffleEdge(graph) {
+		return nil, fmt.Errorf("job %q has shuffle edges; cross-worker shuffle is not yet supported (Phase 2)", job.ID)
+	}
+
 	p := job.Parallelism
 	if p < 1 {
 		p = 1
@@ -163,6 +203,17 @@ func generateTaskDescriptors(job *JobMeta) []rpc.TaskDescriptor {
 	groupsPerTask := totalKeyGroups / p
 	remainder := totalKeyGroups % p
 
+	// The task's OperatorID is the first non-source operator's ID, or the
+	// source itself if the chain is source-only. This preserves the
+	// "one task per subtask of a logical operator" shape for Phase 2.
+	primaryOpID := sorted[0].OperatorID
+	for _, od := range sorted {
+		if od.Type != rpc.OperatorTypeSource {
+			primaryOpID = od.OperatorID
+			break
+		}
+	}
+
 	offset := int32(0)
 	for i := 0; i < p; i++ {
 		size := int32(groupsPerTask)
@@ -170,18 +221,81 @@ func generateTaskDescriptors(job *JobMeta) []rpc.TaskDescriptor {
 			size++
 		}
 		tasks[i] = rpc.TaskDescriptor{
-			TaskID:       fmt.Sprintf("%s/op0/%d", job.ID, i),
-			OperatorID:   "op0",
+			TaskID:       fmt.Sprintf("%s/%s/%d", job.ID, primaryOpID, i),
+			OperatorID:   primaryOpID,
 			SubtaskIndex: int32(i),
 			Parallelism:  int32(p),
 			KeyGroup: rpc.KeyGroupRange{
 				Start: offset,
 				End:   offset + size - 1,
 			},
+			OperatorChain: sorted,
 		}
 		offset += size
 	}
-	return tasks
+	return tasks, nil
+}
+
+// topoSortOperators returns the operators of the graph in topological order.
+// Assumes a valid DAG; returns an error on cycles.
+func topoSortOperators(graph rpc.JobGraph) ([]rpc.OperatorDescriptor, error) {
+	byID := make(map[string]rpc.OperatorDescriptor, len(graph.Operators))
+	inDegree := make(map[string]int, len(graph.Operators))
+	adj := make(map[string][]string, len(graph.Operators))
+	for _, op := range graph.Operators {
+		byID[op.OperatorID] = op
+		inDegree[op.OperatorID] = 0
+	}
+	for _, edge := range graph.Edges {
+		if _, ok := byID[edge.SourceOperatorID]; !ok {
+			return nil, fmt.Errorf("edge references unknown source operator %q", edge.SourceOperatorID)
+		}
+		if _, ok := byID[edge.TargetOperatorID]; !ok {
+			return nil, fmt.Errorf("edge references unknown target operator %q", edge.TargetOperatorID)
+		}
+		adj[edge.SourceOperatorID] = append(adj[edge.SourceOperatorID], edge.TargetOperatorID)
+		inDegree[edge.TargetOperatorID]++
+	}
+
+	// Kahn's algorithm. To keep output deterministic, push onto the ready
+	// queue in insertion order of graph.Operators rather than map order.
+	var queue []string
+	seen := make(map[string]bool)
+	for _, op := range graph.Operators {
+		if inDegree[op.OperatorID] == 0 && !seen[op.OperatorID] {
+			queue = append(queue, op.OperatorID)
+			seen[op.OperatorID] = true
+		}
+	}
+
+	result := make([]rpc.OperatorDescriptor, 0, len(graph.Operators))
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		result = append(result, byID[id])
+		for _, next := range adj[id] {
+			inDegree[next]--
+			if inDegree[next] == 0 {
+				queue = append(queue, next)
+			}
+		}
+	}
+	if len(result) != len(graph.Operators) {
+		return nil, fmt.Errorf("job graph has a cycle")
+	}
+	return result, nil
+}
+
+// hasShuffleEdge returns true if any edge requires partitioning (Hash /
+// Rebalance / Broadcast). Forward edges are safe for Phase 1.
+func hasShuffleEdge(graph rpc.JobGraph) bool {
+	for _, edge := range graph.Edges {
+		switch edge.Shuffle {
+		case rpc.ShuffleStrategyHash, rpc.ShuffleStrategyRebalance, rpc.ShuffleStrategyBroadcast:
+			return true
+		}
+	}
+	return false
 }
 
 // assignTasks distributes tasks across available workers.

--- a/internal/coordinator/scheduler_test.go
+++ b/internal/coordinator/scheduler_test.go
@@ -1,0 +1,190 @@
+package coordinator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tarungka/wire/internal/protocol"
+	"github.com/tarungka/wire/internal/rpc"
+)
+
+// linearGraph builds a JobGraph for "src -> m -> snk" with forward edges.
+func linearGraph() rpc.JobGraph {
+	return rpc.JobGraph{
+		Operators: []rpc.OperatorDescriptor{
+			{OperatorID: "src", Type: rpc.OperatorTypeSource, ClassName: "memory-source"},
+			{OperatorID: "m", Type: rpc.OperatorTypeMap, ClassName: "upper"},
+			{OperatorID: "snk", Type: rpc.OperatorTypeSink, ClassName: "memory-sink"},
+		},
+		Edges: []rpc.EdgeDescriptor{
+			{SourceOperatorID: "src", TargetOperatorID: "m", Shuffle: rpc.ShuffleStrategyForward},
+			{SourceOperatorID: "m", TargetOperatorID: "snk", Shuffle: rpc.ShuffleStrategyForward},
+		},
+	}
+}
+
+func encode(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := protocol.EncodeMsgPack(v)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return b
+}
+
+func TestGenerateTaskDescriptors_LinearGraph(t *testing.T) {
+	graph := linearGraph()
+	job := &JobMeta{
+		ID:          "job-1",
+		Parallelism: 2,
+		Config:      encode(t, graph),
+	}
+
+	tasks, err := generateTaskDescriptors(job)
+	if err != nil {
+		t.Fatalf("generateTaskDescriptors: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks (parallelism=2), got %d", len(tasks))
+	}
+
+	// Each task carries the full topo-sorted chain (Source, Map, Sink).
+	for i, td := range tasks {
+		if got, want := len(td.OperatorChain), 3; got != want {
+			t.Fatalf("task %d: chain len got %d want %d", i, got, want)
+		}
+		ids := []string{td.OperatorChain[0].OperatorID, td.OperatorChain[1].OperatorID, td.OperatorChain[2].OperatorID}
+		want := []string{"src", "m", "snk"}
+		for k := range want {
+			if ids[k] != want[k] {
+				t.Fatalf("task %d: chain ids = %v, want %v", i, ids, want)
+			}
+		}
+
+		// Subtask index reflects ordinal; primary OperatorID is the first
+		// non-source operator in the chain.
+		if td.SubtaskIndex != int32(i) {
+			t.Errorf("task %d: SubtaskIndex got %d want %d", i, td.SubtaskIndex, i)
+		}
+		if td.OperatorID != "m" {
+			t.Errorf("task %d: OperatorID got %q want %q", i, td.OperatorID, "m")
+		}
+		if td.Parallelism != 2 {
+			t.Errorf("task %d: Parallelism got %d want %d", i, td.Parallelism, 2)
+		}
+	}
+
+	// KeyGroup ranges must cover [0, 127] without overlap.
+	if tasks[0].KeyGroup.Start != 0 {
+		t.Errorf("first KeyGroup start = %d, want 0", tasks[0].KeyGroup.Start)
+	}
+	if tasks[len(tasks)-1].KeyGroup.End != 127 {
+		t.Errorf("last KeyGroup end = %d, want 127", tasks[len(tasks)-1].KeyGroup.End)
+	}
+	if tasks[0].KeyGroup.End+1 != tasks[1].KeyGroup.Start {
+		t.Errorf("KeyGroup ranges not contiguous: %v then %v", tasks[0].KeyGroup, tasks[1].KeyGroup)
+	}
+}
+
+func TestGenerateTaskDescriptors_RejectsEmptyConfig(t *testing.T) {
+	job := &JobMeta{ID: "job-x", Parallelism: 1, Config: nil}
+	_, err := generateTaskDescriptors(job)
+	if err == nil {
+		t.Fatal("expected error for empty config")
+	}
+	if !strings.Contains(err.Error(), "no graph") && !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("error %q should mention empty/missing graph", err)
+	}
+}
+
+func TestGenerateTaskDescriptors_RejectsBadConfig(t *testing.T) {
+	job := &JobMeta{ID: "job-x", Parallelism: 1, Config: []byte{0xff, 0xfe, 0xfd, 0xfc}}
+	_, err := generateTaskDescriptors(job)
+	if err == nil {
+		t.Fatal("expected decode error for garbage config")
+	}
+}
+
+func TestGenerateTaskDescriptors_RejectsShuffleEdge(t *testing.T) {
+	graph := linearGraph()
+	graph.Edges[0].Shuffle = rpc.ShuffleStrategyHash // first edge becomes a shuffle
+	job := &JobMeta{ID: "job-shuffle", Parallelism: 1, Config: encode(t, graph)}
+
+	_, err := generateTaskDescriptors(job)
+	if err == nil {
+		t.Fatal("expected error for shuffle edge in Phase 1")
+	}
+	if !strings.Contains(err.Error(), "shuffle") && !strings.Contains(err.Error(), "Phase 2") {
+		t.Fatalf("error %q should mention shuffle/Phase 2", err)
+	}
+}
+
+func TestGenerateTaskDescriptors_RejectsCycle(t *testing.T) {
+	graph := rpc.JobGraph{
+		Operators: []rpc.OperatorDescriptor{
+			{OperatorID: "a", Type: rpc.OperatorTypeMap, ClassName: "x"},
+			{OperatorID: "b", Type: rpc.OperatorTypeMap, ClassName: "x"},
+		},
+		Edges: []rpc.EdgeDescriptor{
+			{SourceOperatorID: "a", TargetOperatorID: "b", Shuffle: rpc.ShuffleStrategyForward},
+			{SourceOperatorID: "b", TargetOperatorID: "a", Shuffle: rpc.ShuffleStrategyForward},
+		},
+	}
+	job := &JobMeta{ID: "job-cycle", Parallelism: 1, Config: encode(t, graph)}
+
+	_, err := generateTaskDescriptors(job)
+	if err == nil {
+		t.Fatal("expected cycle error")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("error %q should mention cycle", err)
+	}
+}
+
+func TestGenerateTaskDescriptors_RejectsDanglingEdge(t *testing.T) {
+	graph := rpc.JobGraph{
+		Operators: []rpc.OperatorDescriptor{
+			{OperatorID: "a", Type: rpc.OperatorTypeSource, ClassName: "src"},
+			{OperatorID: "b", Type: rpc.OperatorTypeSink, ClassName: "snk"},
+		},
+		Edges: []rpc.EdgeDescriptor{
+			// References operator "ghost" that is not declared.
+			{SourceOperatorID: "a", TargetOperatorID: "ghost", Shuffle: rpc.ShuffleStrategyForward},
+		},
+	}
+	job := &JobMeta{ID: "job-dangling", Parallelism: 1, Config: encode(t, graph)}
+
+	_, err := generateTaskDescriptors(job)
+	if err == nil {
+		t.Fatal("expected error for edge referencing unknown operator")
+	}
+}
+
+func TestTopoSortOperators_DeterministicOrder(t *testing.T) {
+	// Two valid topo orderings exist for "a -> c, b -> c"; we want stable
+	// output that follows the input order of graph.Operators (a, b, c).
+	graph := rpc.JobGraph{
+		Operators: []rpc.OperatorDescriptor{
+			{OperatorID: "a", Type: rpc.OperatorTypeSource, ClassName: "x"},
+			{OperatorID: "b", Type: rpc.OperatorTypeSource, ClassName: "x"},
+			{OperatorID: "c", Type: rpc.OperatorTypeSink, ClassName: "x"},
+		},
+		Edges: []rpc.EdgeDescriptor{
+			{SourceOperatorID: "a", TargetOperatorID: "c", Shuffle: rpc.ShuffleStrategyForward},
+			{SourceOperatorID: "b", TargetOperatorID: "c", Shuffle: rpc.ShuffleStrategyForward},
+		},
+	}
+	for i := 0; i < 10; i++ {
+		sorted, err := topoSortOperators(graph)
+		if err != nil {
+			t.Fatalf("topoSort: %v", err)
+		}
+		ids := []string{sorted[0].OperatorID, sorted[1].OperatorID, sorted[2].OperatorID}
+		want := []string{"a", "b", "c"}
+		for k := range want {
+			if ids[k] != want[k] {
+				t.Fatalf("iteration %d: order = %v, want %v", i, ids, want)
+			}
+		}
+	}
+}

--- a/internal/coordinator/scheduler_test.go
+++ b/internal/coordinator/scheduler_test.go
@@ -3,6 +3,9 @@ package coordinator
 import (
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
 
 	"github.com/tarungka/wire/internal/protocol"
 	"github.com/tarungka/wire/internal/rpc"
@@ -157,6 +160,46 @@ func TestGenerateTaskDescriptors_RejectsDanglingEdge(t *testing.T) {
 	_, err := generateTaskDescriptors(job)
 	if err == nil {
 		t.Fatal("expected error for edge referencing unknown operator")
+	}
+}
+
+// TestScheduleJob_BadConfigGoesToFailed verifies that a job whose Config
+// can't be decoded (e.g. legacy or pre-Phase-1 submission) is transitioned
+// all the way to JobFailed instead of being left in JobFailing forever.
+func TestScheduleJob_BadConfigGoesToFailed(t *testing.T) {
+	store := NewMemoryStore()
+	c := New(CoordinatorConfig{NodeID: "n1", ListenAddr: ":0"}, store, nil, zerolog.Nop())
+
+	// Manually drive the coordinator into the leader state without starting
+	// the scheduler goroutine — we want to call scheduleJob directly.
+	c.mu.Lock()
+	c.state = StateLeader
+	c.epoch = 1
+	c.mu.Unlock()
+
+	job := &JobMeta{
+		ID:          "job-bad",
+		Name:        "legacy",
+		Status:      JobCreated,
+		Parallelism: 1,
+		Config:      []byte("not msgpack"),
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	}
+	c.mu.Lock()
+	c.jobs[job.ID] = job
+	c.mu.Unlock()
+	if err := c.persistJob(job); err != nil {
+		t.Fatalf("persistJob: %v", err)
+	}
+
+	c.scheduleJob(job)
+
+	if job.Status != JobFailed {
+		t.Fatalf("status = %s, want %s", job.Status, JobFailed)
+	}
+	if job.FinishedAt.IsZero() {
+		t.Errorf("FinishedAt should be set on terminal state")
 	}
 }
 

--- a/internal/coordinator/transport.go
+++ b/internal/coordinator/transport.go
@@ -40,15 +40,34 @@ func NewTransportServer(coord *Coordinator, listenAddr string, log zerolog.Logge
 	}
 }
 
-// ListenAndServe starts accepting TCP connections. It blocks until ctx is
-// canceled or an unrecoverable error occurs.
-func (ts *TransportServer) ListenAndServe(ctx context.Context) error {
+// Listen binds the server to its configured address without serving. Call
+// Serve() after (or use ListenAndServe for the combined flow). This split
+// lets callers use ":0" and retrieve the actual address via Addr().
+func (ts *TransportServer) Listen() error {
 	ln, err := net.Listen("tcp", ts.listenAddr)
 	if err != nil {
 		return fmt.Errorf("transport server: listen %s: %w", ts.listenAddr, err)
 	}
 	ts.listener = ln
-	ts.log.Info().Str("addr", ts.listenAddr).Msg("transport server listening")
+	ts.log.Info().Str("addr", ln.Addr().String()).Msg("transport server listening")
+	return nil
+}
+
+// Addr returns the listener address. Only valid after Listen() succeeds.
+func (ts *TransportServer) Addr() string {
+	if ts.listener == nil {
+		return ts.listenAddr
+	}
+	return ts.listener.Addr().String()
+}
+
+// Serve starts accepting TCP connections on the already-bound listener. It
+// blocks until ctx is canceled or an unrecoverable error occurs.
+func (ts *TransportServer) Serve(ctx context.Context) error {
+	if ts.listener == nil {
+		return fmt.Errorf("transport server: Serve called before Listen")
+	}
+	ln := ts.listener
 
 	// Close listener when context is canceled.
 	go func() {
@@ -74,6 +93,14 @@ func (ts *TransportServer) ListenAndServe(ctx context.Context) error {
 			ts.handleConn(ctx, c)
 		}(conn)
 	}
+}
+
+// ListenAndServe is a convenience wrapper around Listen() + Serve().
+func (ts *TransportServer) ListenAndServe(ctx context.Context) error {
+	if err := ts.Listen(); err != nil {
+		return err
+	}
+	return ts.Serve(ctx)
 }
 
 // handleConn wraps a raw TCP connection in a Yamux server session and

--- a/internal/coordinator/transport.go
+++ b/internal/coordinator/transport.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"sync"
 
+	"github.com/hashicorp/yamux"
 	"github.com/rs/zerolog"
 
 	"github.com/tarungka/wire/internal/rpc"
@@ -20,6 +21,13 @@ type TransportServer struct {
 	listener   net.Listener
 	log        zerolog.Logger
 	wg         sync.WaitGroup
+
+	// sessionsMu guards the active session set used at shutdown to drop
+	// blocked rpc.ServeSession callers. A worker's Yamux AcceptStream call
+	// otherwise blocks indefinitely even after the listener is closed and
+	// the context is canceled.
+	sessionsMu sync.Mutex
+	sessions   map[*yamux.Session]struct{}
 }
 
 // NewTransportServer creates a TransportServer that bridges worker RPC
@@ -37,6 +45,7 @@ func NewTransportServer(coord *Coordinator, listenAddr string, log zerolog.Logge
 		listenAddr: listenAddr,
 		rpcServer:  srv,
 		log:        log.With().Str("component", "transport-server").Logger(),
+		sessions:   make(map[*yamux.Session]struct{}),
 	}
 }
 
@@ -114,17 +123,36 @@ func (ts *TransportServer) handleConn(ctx context.Context, conn net.Conn) {
 		return
 	}
 
+	ymx := session.YamuxSession()
+	ts.sessionsMu.Lock()
+	ts.sessions[ymx] = struct{}{}
+	ts.sessionsMu.Unlock()
+	defer func() {
+		ts.sessionsMu.Lock()
+		delete(ts.sessions, ymx)
+		ts.sessionsMu.Unlock()
+	}()
+
 	ts.log.Info().Str("remote", session.Addr()).Msg("worker connected")
-	ts.rpcServer.ServeSession(ctx, session.YamuxSession())
+	ts.rpcServer.ServeSession(ctx, ymx)
 	ts.log.Info().Str("remote", session.Addr()).Msg("worker disconnected")
 }
 
-// Shutdown closes the listener and waits for all connections to drain.
+// Shutdown closes the listener, drops every active worker session so any
+// rpc.ServeSession call blocked on AcceptStream returns, then waits for the
+// connection goroutines to drain. Order matters: closing the listener alone
+// prevents *new* connections but does not unblock existing ones, so we must
+// close the sessions first.
 func (ts *TransportServer) Shutdown(_ context.Context) error {
 	if ts.listener != nil {
 		_ = ts.listener.Close()
 	}
-	ts.wg.Wait()
+	ts.sessionsMu.Lock()
+	for s := range ts.sessions {
+		_ = s.Close()
+	}
+	ts.sessionsMu.Unlock()
 	ts.rpcServer.Stop()
+	ts.wg.Wait()
 	return nil
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,9 +53,16 @@ func GetLogger(serviceName string) zerolog.Logger {
 			PartsExclude: []string{
 				zerolog.TimestampFieldName,
 			}}
-		// Use multi-writer for file and readable console output
-		multiDev := zerolog.MultiLevelWriter(consoleWriter, logFile)
-		globalLogger = zerolog.New(multiDev).Level(zerolog.TraceLevel).With().Timestamp().Str("service", serviceName).Caller().Logger()
+		// Use multi-writer for file and readable console output. logFile is
+		// only attached if a caller has set it via SetLogFile — passing a nil
+		// *os.File into MultiLevelWriter causes EINVAL on every write and
+		// prints "zerolog: could not write event: invalid argument" to
+		// stderr, which is the user-visible noise pre-fix.
+		var writer io.Writer = consoleWriter
+		if logFile != nil {
+			writer = zerolog.MultiLevelWriter(consoleWriter, logFile)
+		}
+		globalLogger = zerolog.New(writer).Level(zerolog.TraceLevel).With().Timestamp().Str("service", serviceName).Caller().Logger()
 	})
 
 	return globalLogger

--- a/internal/rpc/messages.go
+++ b/internal/rpc/messages.go
@@ -273,14 +273,20 @@ type EdgeDescriptor struct {
 }
 
 // TaskDescriptor describes a single task instance to deploy.
+//
+// OperatorChain carries the linear sub-chain of operators this task should
+// fuse and execute locally. For Phase 1 (linear pipelines, no shuffle), this
+// is the full source→ops→sink chain. In later phases, it's the slice of
+// operators between two shuffle boundaries.
 type TaskDescriptor struct {
-	TaskID       string                  `codec:"tid"`
-	OperatorID   string                  `codec:"oid"`
-	SubtaskIndex int32                   `codec:"si"`
-	Parallelism  int32                   `codec:"p"`
-	KeyGroup     KeyGroupRange           `codec:"kg"`
-	Upstream     []UpstreamChannelInfo   `codec:"up,omitempty"`
-	Downstream   []DownstreamChannelInfo `codec:"dn,omitempty"`
+	TaskID        string                  `codec:"tid"`
+	OperatorID    string                  `codec:"oid"`
+	SubtaskIndex  int32                   `codec:"si"`
+	Parallelism   int32                   `codec:"p"`
+	KeyGroup      KeyGroupRange           `codec:"kg"`
+	OperatorChain []OperatorDescriptor    `codec:"oc,omitempty"`
+	Upstream      []UpstreamChannelInfo   `codec:"up,omitempty"`
+	Downstream    []DownstreamChannelInfo `codec:"dn,omitempty"`
 }
 
 // KeyGroupRange defines the key-group range assigned to a task.

--- a/internal/worker/integration_test.go
+++ b/internal/worker/integration_test.go
@@ -1,0 +1,198 @@
+package worker_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/tarungka/wire/internal/coordinator"
+	"github.com/tarungka/wire/internal/engine"
+	"github.com/tarungka/wire/internal/protocol"
+	"github.com/tarungka/wire/internal/worker"
+	"github.com/tarungka/wire/sdk"
+	"github.com/tarungka/wire/sdk/connectors/memory"
+)
+
+// TestClusterExecution_LinearPipeline verifies that an SDK-built linear
+// pipeline (Source → Map → Sink) submitted in Cluster mode flows through a
+// coordinator and a live worker process, and that the sink captures the
+// expected mapped events.
+//
+// This is the Phase 1 MVP end-to-end test: it proves that the worker
+// actually instantiates operators and processes data, not just reports
+// Running status.
+func TestClusterExecution_LinearPipeline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// --- Boot coordinator ---
+
+	store := coordinator.NewMemoryStore()
+	coord := coordinator.New(coordinator.CoordinatorConfig{
+		NodeID:     "test-coord",
+		ListenAddr: "127.0.0.1:0",
+	}, store, nil /* single-node */, zerolog.Nop())
+
+	coordDone := make(chan error, 1)
+	go func() { coordDone <- coord.Run(ctx) }()
+
+	waitFor(t, 2*time.Second, func() bool { return coord.IsReady() })
+
+	// --- Transport server (worker RPC) ---
+
+	transportSrv := coordinator.NewTransportServer(coord, "127.0.0.1:0", zerolog.Nop())
+	if err := transportSrv.Listen(); err != nil {
+		t.Fatalf("transport Listen: %v", err)
+	}
+	transportDone := make(chan error, 1)
+	go func() { transportDone <- transportSrv.Serve(ctx) }()
+	defer transportSrv.Shutdown(context.Background())
+
+	// --- HTTP server ---
+
+	httpSrv := coordinator.NewHTTPServer(coord, "127.0.0.1:0", zerolog.Nop())
+	if err := httpSrv.Listen(); err != nil {
+		t.Fatalf("http Listen: %v", err)
+	}
+	httpDone := make(chan error, 1)
+	go func() { httpDone <- httpSrv.Serve() }()
+	defer httpSrv.Shutdown(context.Background())
+
+	// --- Registry + worker ---
+
+	// Use a fresh sinkID so parallel test runs don't collide.
+	sinkID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	defer memory.Reset(sinkID)
+
+	reg := worker.NewRegistry()
+	reg.RegisterSource("memory-source", memory.SourceFactory())
+	reg.RegisterMap("upper", upperMapFactory())
+	reg.RegisterSink("memory-sink", memory.SinkFactory())
+
+	w := worker.NewWithRegistry(worker.Config{
+		WorkerID:        "test-worker",
+		CoordinatorAddr: transportSrv.Addr(),
+		TaskSlots:       4,
+	}, reg, zerolog.Nop())
+	workerDone := make(chan error, 1)
+	go func() { workerDone <- w.Run(ctx) }()
+	defer w.Shutdown(context.Background())
+
+	// Wait for the worker to register.
+	waitFor(t, 3*time.Second, func() bool {
+		workers := coord.ListWorkers()
+		return len(workers) == 1 && workers[0].ID == "test-worker"
+	})
+
+	// --- Build and submit an SDK pipeline in Cluster mode ---
+
+	events := [][]byte{[]byte("hello"), []byte("world"), []byte("wire")}
+	sourceCfg := mustMsgpack(t, memory.SourceConfig{Events: events})
+	sinkCfg := mustMsgpack(t, memory.SinkConfig{SinkID: sinkID})
+
+	env := sdk.New().
+		SetMode(sdk.Cluster).
+		SetCoordinator("http://" + httpSrv.Addr()).
+		SetParallelism(1)
+
+	env.AddSourceNamed("src", "memory-source", sourceCfg).
+		MapNamed("upper", "upper", nil).
+		AddSinkNamed("sink", "memory-sink", sinkCfg)
+
+	res, err := env.ExecuteWithName(ctx, "phase1-mvp")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("job err: %v", res.Err)
+	}
+
+	// --- Assert the sink captured the expected events ---
+
+	got := memory.Collected(sinkID)
+	wantValues := []string{"HELLO", "WORLD", "WIRE"}
+	if len(got) != len(wantValues) {
+		t.Fatalf("collected %d events, want %d; got=%v", len(got), len(wantValues), valuesOf(got))
+	}
+	gotVals := valuesOf(got)
+	if !equalStrings(gotVals, wantValues) {
+		t.Fatalf("collected values mismatch: got=%v want=%v", gotVals, wantValues)
+	}
+}
+
+// upperMapFactory returns a MapFactory whose operator uppercases the Value
+// of each event. It is the user-defined function for this test.
+func upperMapFactory() worker.MapFactory {
+	return func(_ context.Context, _ []byte, _ worker.TaskContext) (engine.MapOperator, error) {
+		return &upperMap{}, nil
+	}
+}
+
+type upperMap struct{}
+
+func (*upperMap) Open(_ context.Context) error        { return nil }
+func (*upperMap) Close() error                        { return nil }
+func (*upperMap) Checkpoint(_ uint64) ([]byte, error) { return nil, nil }
+func (*upperMap) Map(_ context.Context, e engine.Event) (engine.Event, error) {
+	e.Value = []byte(strings.ToUpper(string(e.Value)))
+	return e, nil
+}
+
+var _ engine.MapOperator = (*upperMap)(nil)
+
+// --- Helpers ---
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("condition not satisfied within %s", timeout)
+}
+
+func mustMsgpack(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := protocol.EncodeMsgPack(v)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return b
+}
+
+func valuesOf(events []engine.Event) []string {
+	out := make([]string, len(events))
+	for i, e := range events {
+		out[i] = string(e.Value)
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	// Order doesn't matter within a single subtask (Phase 1 parallelism=1
+	// preserves order, but be resilient).
+	am := make(map[string]int)
+	for _, s := range a {
+		am[s]++
+	}
+	for _, s := range b {
+		am[s]--
+	}
+	for _, n := range am {
+		if n != 0 {
+			return false
+		}
+	}
+	return true
+}
+

--- a/internal/worker/registry.go
+++ b/internal/worker/registry.go
@@ -1,0 +1,178 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/rs/zerolog"
+
+	"github.com/tarungka/wire/internal/engine"
+	"github.com/tarungka/wire/internal/rpc"
+)
+
+// TaskContext is passed to an operator factory when a task is deployed.
+// It carries per-task identity and scheduling information.
+type TaskContext struct {
+	TaskID       string
+	JobID        string
+	OperatorID   string
+	SubtaskIndex int32
+	Parallelism  int32
+	KeyGroup     rpc.KeyGroupRange
+	Log          zerolog.Logger
+}
+
+// Factory types. Each factory receives the operator's config bytes (verbatim
+// from OperatorDescriptor.Config) and a TaskContext, and returns a live
+// engine operator ready to be opened and run.
+type (
+	SourceFactory  func(ctx context.Context, cfg []byte, tc TaskContext) (engine.SourceOperator, error)
+	MapFactory     func(ctx context.Context, cfg []byte, tc TaskContext) (engine.MapOperator, error)
+	FlatMapFactory func(ctx context.Context, cfg []byte, tc TaskContext) (engine.FlatMapOperator, error)
+	SinkFactory    func(ctx context.Context, cfg []byte, tc TaskContext) (engine.SinkOperator, error)
+)
+
+// Registry maps operator ClassName strings to factory functions. A worker
+// looks up factories by the ClassName in each OperatorDescriptor at task
+// deploy time.
+type Registry struct {
+	mu       sync.RWMutex
+	sources  map[string]SourceFactory
+	maps     map[string]MapFactory
+	flatMaps map[string]FlatMapFactory
+	sinks    map[string]SinkFactory
+}
+
+// NewRegistry returns an empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		sources:  make(map[string]SourceFactory),
+		maps:     make(map[string]MapFactory),
+		flatMaps: make(map[string]FlatMapFactory),
+		sinks:    make(map[string]SinkFactory),
+	}
+}
+
+// RegisterSource adds a source factory. Panics on duplicate name to surface
+// configuration mistakes at startup.
+func (r *Registry) RegisterSource(name string, f SourceFactory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.sources[name]; exists {
+		panic(fmt.Sprintf("worker: source %q already registered", name))
+	}
+	r.sources[name] = f
+}
+
+// RegisterMap adds a map factory. Panics on duplicate name.
+func (r *Registry) RegisterMap(name string, f MapFactory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.maps[name]; exists {
+		panic(fmt.Sprintf("worker: map %q already registered", name))
+	}
+	r.maps[name] = f
+}
+
+// RegisterFlatMap adds a flat-map factory. Panics on duplicate name.
+func (r *Registry) RegisterFlatMap(name string, f FlatMapFactory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.flatMaps[name]; exists {
+		panic(fmt.Sprintf("worker: flatmap %q already registered", name))
+	}
+	r.flatMaps[name] = f
+}
+
+// RegisterSink adds a sink factory. Panics on duplicate name.
+func (r *Registry) RegisterSink(name string, f SinkFactory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.sinks[name]; exists {
+		panic(fmt.Sprintf("worker: sink %q already registered", name))
+	}
+	r.sinks[name] = f
+}
+
+// Build resolves an OperatorDescriptor to a concrete engine.Operator by
+// looking up the factory keyed by desc.ClassName. Filter operators are
+// handled by the "filter" factory type on maps (a filter is a map that
+// conditionally returns a zero event).
+func (r *Registry) Build(ctx context.Context, desc rpc.OperatorDescriptor, tc TaskContext) (engine.Operator, error) {
+	if desc.ClassName == "" {
+		return nil, fmt.Errorf("worker: operator %q has no ClassName (required for cluster mode)", desc.OperatorID)
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	switch desc.Type {
+	case rpc.OperatorTypeSource:
+		f, ok := r.sources[desc.ClassName]
+		if !ok {
+			return nil, fmt.Errorf("worker: unknown source %q (did you forget to register it?)", desc.ClassName)
+		}
+		op, err := f(ctx, desc.Config, tc)
+		if err != nil {
+			return nil, fmt.Errorf("worker: source %q factory: %w", desc.ClassName, err)
+		}
+		return op, nil
+
+	case rpc.OperatorTypeMap, rpc.OperatorTypeFilter:
+		f, ok := r.maps[desc.ClassName]
+		if !ok {
+			return nil, fmt.Errorf("worker: unknown map/filter %q", desc.ClassName)
+		}
+		op, err := f(ctx, desc.Config, tc)
+		if err != nil {
+			return nil, fmt.Errorf("worker: map %q factory: %w", desc.ClassName, err)
+		}
+		return op, nil
+
+	case rpc.OperatorTypeFlatMap:
+		f, ok := r.flatMaps[desc.ClassName]
+		if !ok {
+			return nil, fmt.Errorf("worker: unknown flatmap %q", desc.ClassName)
+		}
+		op, err := f(ctx, desc.Config, tc)
+		if err != nil {
+			return nil, fmt.Errorf("worker: flatmap %q factory: %w", desc.ClassName, err)
+		}
+		return op, nil
+
+	case rpc.OperatorTypeSink:
+		f, ok := r.sinks[desc.ClassName]
+		if !ok {
+			return nil, fmt.Errorf("worker: unknown sink %q", desc.ClassName)
+		}
+		op, err := f(ctx, desc.Config, tc)
+		if err != nil {
+			return nil, fmt.Errorf("worker: sink %q factory: %w", desc.ClassName, err)
+		}
+		return op, nil
+
+	default:
+		return nil, fmt.Errorf("worker: operator type %s is not supported in Phase 1", desc.Type)
+	}
+}
+
+// defaultRegistry is the package-level registry used by convenience functions.
+// User code typically calls worker.RegisterSource/RegisterMap/... in init or
+// main before constructing a Worker.
+var defaultRegistry = NewRegistry()
+
+// DefaultRegistry returns the package-level registry.
+func DefaultRegistry() *Registry { return defaultRegistry }
+
+// RegisterSource registers a source factory in the default registry.
+func RegisterSource(name string, f SourceFactory) { defaultRegistry.RegisterSource(name, f) }
+
+// RegisterMap registers a map factory in the default registry.
+func RegisterMap(name string, f MapFactory) { defaultRegistry.RegisterMap(name, f) }
+
+// RegisterFlatMap registers a flat-map factory in the default registry.
+func RegisterFlatMap(name string, f FlatMapFactory) { defaultRegistry.RegisterFlatMap(name, f) }
+
+// RegisterSink registers a sink factory in the default registry.
+func RegisterSink(name string, f SinkFactory) { defaultRegistry.RegisterSink(name, f) }

--- a/internal/worker/registry_test.go
+++ b/internal/worker/registry_test.go
@@ -1,0 +1,209 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/tarungka/wire/internal/engine"
+	"github.com/tarungka/wire/internal/rpc"
+)
+
+// stubSource is a no-op SourceOperator for registry tests.
+type stubSource struct{}
+
+func (*stubSource) Open(_ context.Context) error                    { return nil }
+func (*stubSource) Close() error                                    { return nil }
+func (*stubSource) Checkpoint(_ uint64) ([]byte, error)             { return nil, nil }
+func (*stubSource) ReadBatch(_ context.Context) ([]engine.Event, error) { return nil, nil }
+func (*stubSource) GenerateWatermark() int64                        { return 0 }
+
+type stubMap struct{}
+
+func (*stubMap) Open(_ context.Context) error        { return nil }
+func (*stubMap) Close() error                        { return nil }
+func (*stubMap) Checkpoint(_ uint64) ([]byte, error) { return nil, nil }
+func (*stubMap) Map(_ context.Context, e engine.Event) (engine.Event, error) {
+	return e, nil
+}
+
+type stubFlatMap struct{}
+
+func (*stubFlatMap) Open(_ context.Context) error        { return nil }
+func (*stubFlatMap) Close() error                        { return nil }
+func (*stubFlatMap) Checkpoint(_ uint64) ([]byte, error) { return nil, nil }
+func (*stubFlatMap) FlatMap(_ context.Context, _ engine.Event, _ func(engine.Event)) error {
+	return nil
+}
+
+type stubSink struct{}
+
+func (*stubSink) Open(_ context.Context) error                            { return nil }
+func (*stubSink) Close() error                                            { return nil }
+func (*stubSink) Checkpoint(_ uint64) ([]byte, error)                     { return nil, nil }
+func (*stubSink) Write(_ context.Context, _ engine.Event) error           { return nil }
+
+func newTC() TaskContext { return TaskContext{Log: zerolog.Nop()} }
+
+func TestRegistry_BuildSource(t *testing.T) {
+	r := NewRegistry()
+	r.RegisterSource("src", func(_ context.Context, _ []byte, _ TaskContext) (engine.SourceOperator, error) {
+		return &stubSource{}, nil
+	})
+
+	op, err := r.Build(context.Background(), rpc.OperatorDescriptor{
+		OperatorID: "op-1",
+		Type:       rpc.OperatorTypeSource,
+		ClassName:  "src",
+	}, newTC())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if _, ok := op.(engine.SourceOperator); !ok {
+		t.Fatalf("Build returned %T, want engine.SourceOperator", op)
+	}
+}
+
+func TestRegistry_BuildMapAndFlatMapAndSink(t *testing.T) {
+	r := NewRegistry()
+	r.RegisterMap("m", func(_ context.Context, _ []byte, _ TaskContext) (engine.MapOperator, error) {
+		return &stubMap{}, nil
+	})
+	r.RegisterFlatMap("fm", func(_ context.Context, _ []byte, _ TaskContext) (engine.FlatMapOperator, error) {
+		return &stubFlatMap{}, nil
+	})
+	r.RegisterSink("snk", func(_ context.Context, _ []byte, _ TaskContext) (engine.SinkOperator, error) {
+		return &stubSink{}, nil
+	})
+
+	cases := []struct {
+		desc rpc.OperatorDescriptor
+		want any
+	}{
+		{rpc.OperatorDescriptor{OperatorID: "1", Type: rpc.OperatorTypeMap, ClassName: "m"}, (*stubMap)(nil)},
+		{rpc.OperatorDescriptor{OperatorID: "2", Type: rpc.OperatorTypeFilter, ClassName: "m"}, (*stubMap)(nil)},
+		{rpc.OperatorDescriptor{OperatorID: "3", Type: rpc.OperatorTypeFlatMap, ClassName: "fm"}, (*stubFlatMap)(nil)},
+		{rpc.OperatorDescriptor{OperatorID: "4", Type: rpc.OperatorTypeSink, ClassName: "snk"}, (*stubSink)(nil)},
+	}
+	for _, c := range cases {
+		op, err := r.Build(context.Background(), c.desc, newTC())
+		if err != nil {
+			t.Fatalf("Build %s/%s: %v", c.desc.Type, c.desc.ClassName, err)
+		}
+		// Type-check: op should be assignable to the want type.
+		switch c.want.(type) {
+		case *stubMap:
+			if _, ok := op.(*stubMap); !ok {
+				t.Fatalf("%s: got %T", c.desc.Type, op)
+			}
+		case *stubFlatMap:
+			if _, ok := op.(*stubFlatMap); !ok {
+				t.Fatalf("%s: got %T", c.desc.Type, op)
+			}
+		case *stubSink:
+			if _, ok := op.(*stubSink); !ok {
+				t.Fatalf("%s: got %T", c.desc.Type, op)
+			}
+		}
+	}
+}
+
+func TestRegistry_MissingClassName(t *testing.T) {
+	r := NewRegistry()
+	_, err := r.Build(context.Background(), rpc.OperatorDescriptor{
+		OperatorID: "x",
+		Type:       rpc.OperatorTypeMap,
+		ClassName:  "",
+	}, newTC())
+	if err == nil {
+		t.Fatal("expected error for empty ClassName")
+	}
+	if !strings.Contains(err.Error(), "ClassName") {
+		t.Fatalf("error %q should mention ClassName", err)
+	}
+}
+
+func TestRegistry_UnknownClass(t *testing.T) {
+	r := NewRegistry()
+	_, err := r.Build(context.Background(), rpc.OperatorDescriptor{
+		OperatorID: "x",
+		Type:       rpc.OperatorTypeMap,
+		ClassName:  "not-registered",
+	}, newTC())
+	if err == nil {
+		t.Fatal("expected error for unknown ClassName")
+	}
+	if !strings.Contains(err.Error(), "not-registered") {
+		t.Fatalf("error %q should name the missing class", err)
+	}
+}
+
+func TestRegistry_FactoryError(t *testing.T) {
+	want := errors.New("boom")
+	r := NewRegistry()
+	r.RegisterMap("m", func(_ context.Context, _ []byte, _ TaskContext) (engine.MapOperator, error) {
+		return nil, want
+	})
+	_, err := r.Build(context.Background(), rpc.OperatorDescriptor{
+		OperatorID: "x",
+		Type:       rpc.OperatorTypeMap,
+		ClassName:  "m",
+	}, newTC())
+	if err == nil {
+		t.Fatal("expected error from factory")
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("error %v should wrap %v", err, want)
+	}
+}
+
+func TestRegistry_DuplicateRegistrationPanics(t *testing.T) {
+	r := NewRegistry()
+	r.RegisterMap("dup", func(_ context.Context, _ []byte, _ TaskContext) (engine.MapOperator, error) {
+		return &stubMap{}, nil
+	})
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on duplicate registration")
+		}
+	}()
+	r.RegisterMap("dup", func(_ context.Context, _ []byte, _ TaskContext) (engine.MapOperator, error) {
+		return &stubMap{}, nil
+	})
+}
+
+func TestRegistry_UnsupportedOperatorType(t *testing.T) {
+	r := NewRegistry()
+	_, err := r.Build(context.Background(), rpc.OperatorDescriptor{
+		OperatorID: "x",
+		Type:       rpc.OperatorTypeWindow, // not yet supported
+		ClassName:  "anything",
+	}, newTC())
+	if err == nil {
+		t.Fatal("expected error for unsupported operator type")
+	}
+}
+
+func TestRegistry_ConfigBytesPropagated(t *testing.T) {
+	var seen []byte
+	r := NewRegistry()
+	r.RegisterMap("m", func(_ context.Context, cfg []byte, _ TaskContext) (engine.MapOperator, error) {
+		seen = cfg
+		return &stubMap{}, nil
+	})
+	want := []byte("hello-cfg")
+	if _, err := r.Build(context.Background(), rpc.OperatorDescriptor{
+		Type:      rpc.OperatorTypeMap,
+		ClassName: "m",
+		Config:    want,
+	}, newTC()); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if string(seen) != string(want) {
+		t.Fatalf("config bytes: got %q want %q", seen, want)
+	}
+}

--- a/internal/worker/task_executor.go
+++ b/internal/worker/task_executor.go
@@ -1,0 +1,131 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/rs/zerolog"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/tarungka/wire/internal/engine"
+	"github.com/tarungka/wire/internal/rpc"
+)
+
+// taskExecutor instantiates operators from a TaskDescriptor and runs them
+// as a fused chain using the engine's operator-chain runtime. It mirrors the
+// wiring of sdk/embedded.go:runLinearInstance but resolves operators by name
+// from the worker's Registry instead of from inline SDK function values.
+type taskExecutor struct {
+	reg *Registry
+}
+
+func newTaskExecutor(reg *Registry) *taskExecutor {
+	return &taskExecutor{reg: reg}
+}
+
+// run builds the operator chain described by desc.OperatorChain, wires
+// channels, and drives execution until ctx is cancelled or the source ends.
+// Phase 1: single-input linear pipeline, no shuffle, no state, no checkpoints.
+func (te *taskExecutor) run(ctx context.Context, jobID, taskID string, desc rpc.TaskDescriptor, log zerolog.Logger) error {
+	if len(desc.OperatorChain) == 0 {
+		return fmt.Errorf("worker: task %q has empty OperatorChain", taskID)
+	}
+
+	tc := TaskContext{
+		TaskID:       taskID,
+		JobID:        jobID,
+		OperatorID:   desc.OperatorID,
+		SubtaskIndex: desc.SubtaskIndex,
+		Parallelism:  desc.Parallelism,
+		KeyGroup:     desc.KeyGroup,
+		Log:          log,
+	}
+
+	var sourceOp engine.SourceOperator
+	var operators []engine.Operator
+
+	for i, od := range desc.OperatorChain {
+		op, err := te.reg.Build(ctx, od, tc)
+		if err != nil {
+			return fmt.Errorf("worker: task %q operator[%d] %q: %w", taskID, i, od.OperatorID, err)
+		}
+		if od.Type == rpc.OperatorTypeSource {
+			so, ok := op.(engine.SourceOperator)
+			if !ok {
+				return fmt.Errorf("worker: operator %q declared Source but factory returned %T", od.OperatorID, op)
+			}
+			if sourceOp != nil {
+				return fmt.Errorf("worker: task %q has multiple sources in chain", taskID)
+			}
+			sourceOp = so
+			continue
+		}
+		operators = append(operators, op)
+	}
+
+	if sourceOp == nil {
+		return fmt.Errorf("worker: task %q has no source in OperatorChain", taskID)
+	}
+
+	// Wire channels identically to sdk/embedded.go:runLinearInstance.
+	eventCh := make(chan engine.Event, engine.DefaultInputBufferSize)
+	controlCh := make(chan engine.ControlMsg, 8)
+	outputCh := make(chan engine.OutputMsg, engine.DefaultOutputBufferSize)
+	aligner := engine.NewBarrierAligner(1, engine.DefaultAlignmentBufferSize)
+
+	runCtx, runCancel := context.WithCancel(ctx)
+	defer runCancel()
+
+	g, gctx := errgroup.WithContext(runCtx)
+
+	// Source goroutine.
+	g.Go(func() error {
+		return engine.RunSourceReader(gctx, sourceOp, nil, eventCh, controlCh, log)
+	})
+
+	// Operator chain goroutine. When it exits (either on context cancellation
+	// or source end-of-partition), cancel the runCtx so the source reader
+	// unblocks and close the output channel so the drainer returns.
+	var producerWg sync.WaitGroup
+	producerWg.Add(1)
+	g.Go(func() error {
+		defer producerWg.Done()
+		defer runCancel()
+		return engine.RunOperatorChain(
+			gctx,
+			operators,
+			eventCh,
+			controlCh,
+			outputCh,
+			aligner,
+			1, // numInputs — Phase 1 single-input.
+			engine.NoopCheckpointMetrics(),
+			log,
+			nil, // txnSink — Phase 1 no 2PC.
+			nil, // ackFn — Phase 1 no checkpoint ack.
+			nil, // errorConfigs
+			nil, // dlqCh
+			engine.NoopErrorMetrics(),
+		)
+	})
+
+	// Close outputCh when the operator chain finishes so the drainer exits.
+	go func() {
+		producerWg.Wait()
+		close(outputCh)
+	}()
+
+	// Linear pipelines have the sink in the chain; discard forwarded events.
+	g.Go(func() error {
+		for range outputCh {
+		}
+		return nil
+	})
+
+	err := g.Wait()
+	if err == context.Canceled {
+		return nil
+	}
+	return err
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -22,23 +22,46 @@ type Config struct {
 	TaskSlots       int
 }
 
-// Worker connects to a coordinator, registers, and runs a heartbeat loop.
-type Worker struct {
-	cfg     Config
-	client  *rpc.Client
-	session *transport.Session
-	epoch   uint64
-	mu      sync.RWMutex
-	tasks   map[string]context.CancelFunc // taskID -> cancel
-	log     zerolog.Logger
+// taskHandle tracks a running task so it can be cancelled on demand or
+// on worker shutdown.
+type taskHandle struct {
+	cancel context.CancelFunc
 }
 
-// New creates a new Worker.
+// Worker connects to a coordinator, registers, and runs a heartbeat loop.
+// Deployed tasks are resolved against the Worker's Registry and executed
+// via taskExecutor.
+type Worker struct {
+	cfg      Config
+	reg      *Registry
+	executor *taskExecutor
+	client   *rpc.Client
+	session  *transport.Session
+	epoch    uint64
+	mu       sync.RWMutex
+	tasks    map[string]*taskHandle // taskID -> handle
+	log      zerolog.Logger
+}
+
+// New creates a new Worker using the package-level default registry. User
+// code should call worker.RegisterSource/RegisterMap/RegisterSink before
+// constructing the Worker.
 func New(cfg Config, log zerolog.Logger) *Worker {
+	return NewWithRegistry(cfg, defaultRegistry, log)
+}
+
+// NewWithRegistry creates a new Worker with an explicit registry. Useful for
+// tests that need isolation from the package-level default registry.
+func NewWithRegistry(cfg Config, reg *Registry, log zerolog.Logger) *Worker {
+	if reg == nil {
+		reg = defaultRegistry
+	}
 	return &Worker{
-		cfg:   cfg,
-		tasks: make(map[string]context.CancelFunc),
-		log:   log.With().Str("component", "worker").Logger(),
+		cfg:      cfg,
+		reg:      reg,
+		executor: newTaskExecutor(reg),
+		tasks:    make(map[string]*taskHandle),
+		log:      log.With().Str("component", "worker").Logger(),
 	}
 }
 
@@ -120,9 +143,9 @@ func (w *Worker) Run(ctx context.Context) error {
 // Shutdown cancels running tasks and closes the transport session.
 func (w *Worker) Shutdown(_ context.Context) error {
 	w.mu.Lock()
-	for taskID, cancel := range w.tasks {
+	for taskID, h := range w.tasks {
 		w.log.Info().Str("task_id", taskID).Msg("canceling task")
-		cancel()
+		h.cancel()
 	}
 	w.mu.Unlock()
 
@@ -151,6 +174,9 @@ func (w *Worker) buildHeartbeatRequest() *rpc.HeartbeatRequest {
 }
 
 // handleDeployTask processes a DeployTask command from the coordinator.
+// It decodes the TaskDescriptor, instantiates the operator chain via the
+// registry, and drives execution in a background goroutine. Task status
+// transitions are reported back to the coordinator via UpdateTaskStatus.
 func (w *Worker) handleDeployTask(cmd rpc.WorkerCommand) {
 	// Idempotent: ignore if task already exists.
 	w.mu.RLock()
@@ -165,43 +191,81 @@ func (w *Worker) handleDeployTask(cmd rpc.WorkerCommand) {
 	var desc rpc.TaskDescriptor
 	if err := protocol.DecodeMsgPack(cmd.Data, &desc); err != nil {
 		w.log.Error().Err(err).Str("task_id", cmd.TaskID).Msg("failed to decode task descriptor")
+		w.reportTaskFailed(cmd.JobID, cmd.TaskID, fmt.Errorf("decode descriptor: %w", err))
 		return
 	}
 
-	// Create task context.
 	taskCtx, cancel := context.WithCancel(context.Background())
 	w.mu.Lock()
-	w.tasks[cmd.TaskID] = cancel
+	w.tasks[cmd.TaskID] = &taskHandle{cancel: cancel}
 	w.mu.Unlock()
 
-	w.log.Info().
+	taskLog := w.log.With().
 		Str("task_id", cmd.TaskID).
 		Str("job_id", cmd.JobID).
 		Str("operator_id", desc.OperatorID).
 		Int32("subtask_index", desc.SubtaskIndex).
-		Msg("deployed task")
+		Logger()
 
-	// Send UpdateTaskStatus(RUNNING) to coordinator.
-	go func() {
-		defer func() {
-			// When the task context is canceled, the task is done.
-			<-taskCtx.Done()
-		}()
+	taskLog.Info().Int("chain_len", len(desc.OperatorChain)).Msg("deployed task")
 
-		w.mu.RLock()
-		epoch := w.epoch
-		w.mu.RUnlock()
+	go w.runTask(taskCtx, cmd.JobID, cmd.TaskID, desc, taskLog)
+}
 
-		statusReq := &rpc.UpdateTaskStatusRequest{
-			JobID:   cmd.JobID,
-			TaskID:  cmd.TaskID,
-			Status:  rpc.TaskStatusRunning,
-			EpochID: epoch,
-		}
-		if _, err := w.client.UpdateTaskStatus(context.Background(), statusReq); err != nil {
-			w.log.Error().Err(err).Str("task_id", cmd.TaskID).Msg("failed to send UpdateTaskStatus")
-		}
+// runTask reports Running on entry, drives the executor, and reports
+// Finished/Failed on exit. Always removes the task from w.tasks when done.
+func (w *Worker) runTask(ctx context.Context, jobID, taskID string, desc rpc.TaskDescriptor, log zerolog.Logger) {
+	defer func() {
+		w.mu.Lock()
+		delete(w.tasks, taskID)
+		w.mu.Unlock()
 	}()
+
+	w.reportTaskStatus(jobID, taskID, rpc.TaskStatusRunning, nil)
+
+	err := w.executor.run(ctx, jobID, taskID, desc, log)
+
+	switch {
+	case err == nil:
+		log.Info().Msg("task finished")
+		w.reportTaskStatus(jobID, taskID, rpc.TaskStatusFinished, nil)
+	case ctx.Err() != nil:
+		log.Info().Msg("task canceled")
+		w.reportTaskStatus(jobID, taskID, rpc.TaskStatusCanceled, nil)
+	default:
+		log.Error().Err(err).Msg("task failed")
+		w.reportTaskFailed(jobID, taskID, err)
+	}
+}
+
+// reportTaskStatus sends an UpdateTaskStatus RPC with no failure info.
+func (w *Worker) reportTaskStatus(jobID, taskID string, status rpc.TaskStatus, failure *rpc.TaskFailureInfo) {
+	w.mu.RLock()
+	epoch := w.epoch
+	w.mu.RUnlock()
+
+	req := &rpc.UpdateTaskStatusRequest{
+		JobID:   jobID,
+		TaskID:  taskID,
+		Status:  status,
+		EpochID: epoch,
+		Failure: failure,
+	}
+	if _, err := w.client.UpdateTaskStatus(context.Background(), req); err != nil {
+		w.log.Error().Err(err).
+			Str("task_id", taskID).
+			Str("status", status.String()).
+			Msg("failed to send UpdateTaskStatus")
+	}
+}
+
+// reportTaskFailed sends an UpdateTaskStatus RPC with status=Failed and the
+// error message populated in the failure info.
+func (w *Worker) reportTaskFailed(jobID, taskID string, err error) {
+	w.reportTaskStatus(jobID, taskID, rpc.TaskStatusFailed, &rpc.TaskFailureInfo{
+		ErrorMessage: err.Error(),
+		Timestamp:    time.Now().UnixMilli(),
+	})
 }
 
 // handleCommands dispatches coordinator commands received via heartbeat responses.
@@ -213,13 +277,13 @@ func (w *Worker) handleCommands(cmds []rpc.WorkerCommand) {
 		case rpc.CommandTypeCancelTask:
 			w.log.Info().Str("task_id", cmd.TaskID).Msg("received CancelTask command")
 			w.mu.Lock()
-			if cancel, ok := w.tasks[cmd.TaskID]; ok {
-				cancel()
-				delete(w.tasks, cmd.TaskID)
+			if h, ok := w.tasks[cmd.TaskID]; ok {
+				h.cancel()
+				// Don't delete here — runTask's defer cleans up.
 			}
 			w.mu.Unlock()
 		case rpc.CommandTypeTakeSnapshot:
-			w.log.Info().Str("task_id", cmd.TaskID).Msg("received TakeSnapshot command (stub)")
+			w.log.Info().Str("task_id", cmd.TaskID).Msg("received TakeSnapshot command (stub — Phase 4)")
 		default:
 			w.log.Warn().Uint8("type", uint8(cmd.Type)).Msg("unknown command type")
 		}

--- a/sdk/cluster.go
+++ b/sdk/cluster.go
@@ -1,14 +1,177 @@
 package sdk
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/tarungka/wire/internal/protocol"
 )
 
-// clusterExecutor submits pipelines to a remote Wire cluster via RPC.
-// Not yet implemented — this is a stub for the cluster execution mode.
-type clusterExecutor struct{}
+// clusterExecutor submits a graph to a remote Wire coordinator via HTTP and
+// polls for completion.
+type clusterExecutor struct {
+	env *StreamExecutionEnvironment
+}
 
-func (ex *clusterExecutor) run(_ context.Context, _ string) (*JobResult, error) {
-	return nil, fmt.Errorf("sdk: cluster mode not yet implemented")
+// submitJobRequest mirrors coordinator.submitJobRequest. Kept in the SDK as
+// a minimal, stable contract.
+type submitJobRequest struct {
+	Name        string `json:"name"`
+	Parallelism int    `json:"parallelism"`
+	Config      string `json:"config,omitempty"`
+	GraphBytes  string `json:"graph_bytes,omitempty"`
+}
+
+// jobStatusResponse is the subset of coordinator.jobDetailResponse that we
+// care about for completion polling.
+type jobStatusResponse struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+func (ex *clusterExecutor) run(ctx context.Context, jobName string) (*JobResult, error) {
+	if ex.env.coordinatorURL == "" {
+		return nil, fmt.Errorf("sdk: cluster mode requires env.SetCoordinator(url)")
+	}
+	start := time.Now()
+
+	// Encode the graph.
+	graph := ex.env.graph.toJobGraph(ex.env.parallelism)
+	graphBytes, err := protocol.EncodeMsgPack(&graph)
+	if err != nil {
+		return nil, fmt.Errorf("sdk: encode job graph: %w", err)
+	}
+
+	if jobName == "" {
+		jobName = fmt.Sprintf("sdk-job-%d", time.Now().UnixNano())
+	}
+
+	// Submit.
+	submit := submitJobRequest{
+		Name:        jobName,
+		Parallelism: ex.env.parallelism,
+		GraphBytes:  base64.StdEncoding.EncodeToString(graphBytes),
+	}
+	jobID, err := ex.submit(ctx, submit)
+	if err != nil {
+		return nil, err
+	}
+
+	// Poll until terminal.
+	finalStatus, err := ex.poll(ctx, jobID)
+	if err != nil {
+		return &JobResult{
+			JobID: jobID,
+			Err:   err,
+			Metrics: JobMetrics{
+				Duration: time.Since(start),
+			},
+		}, err
+	}
+
+	res := &JobResult{
+		JobID: jobID,
+		Metrics: JobMetrics{
+			Duration: time.Since(start),
+		},
+	}
+	switch strings.ToUpper(finalStatus) {
+	case "FINISHED":
+		return res, nil
+	case "FAILED", "CANCELED":
+		res.Err = fmt.Errorf("sdk: job %s ended with status %s", jobID, finalStatus)
+		return res, res.Err
+	default:
+		res.Err = fmt.Errorf("sdk: job %s ended in unexpected state %s", jobID, finalStatus)
+		return res, res.Err
+	}
+}
+
+// submit POSTs the graph to /api/v1/jobs and returns the created jobID.
+func (ex *clusterExecutor) submit(ctx context.Context, body submitJobRequest) (string, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("sdk: encode submit body: %w", err)
+	}
+
+	url := strings.TrimRight(ex.env.coordinatorURL, "/") + "/api/v1/jobs"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(buf))
+	if err != nil {
+		return "", fmt.Errorf("sdk: build submit request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("sdk: submit: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("sdk: submit: %s — %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+
+	var created jobStatusResponse
+	if err := json.Unmarshal(respBody, &created); err != nil {
+		return "", fmt.Errorf("sdk: decode submit response: %w", err)
+	}
+	if created.ID == "" {
+		return "", fmt.Errorf("sdk: submit: server returned empty job ID")
+	}
+	return created.ID, nil
+}
+
+// poll GETs /api/v1/jobs/{jobID} repeatedly until status is terminal or ctx
+// is canceled.
+func (ex *clusterExecutor) poll(ctx context.Context, jobID string) (string, error) {
+	url := strings.TrimRight(ex.env.coordinatorURL, "/") + "/api/v1/jobs/" + jobID
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		status, err := ex.getStatus(ctx, url)
+		if err != nil {
+			return "", err
+		}
+		switch strings.ToUpper(status) {
+		case "FINISHED", "FAILED", "CANCELED":
+			return status, nil
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (ex *clusterExecutor) getStatus(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("sdk: build poll request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("sdk: poll: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("sdk: poll: %s — %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	var s jobStatusResponse
+	if err := json.Unmarshal(body, &s); err != nil {
+		return "", fmt.Errorf("sdk: decode poll response: %w", err)
+	}
+	return s.Status, nil
 }

--- a/sdk/connectors/memory/memory_test.go
+++ b/sdk/connectors/memory/memory_test.go
@@ -1,0 +1,175 @@
+package memory_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tarungka/wire/internal/engine"
+	"github.com/tarungka/wire/internal/protocol"
+	"github.com/tarungka/wire/internal/worker"
+	"github.com/tarungka/wire/sdk/connectors/memory"
+)
+
+func mustEncode(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := protocol.EncodeMsgPack(v)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return b
+}
+
+func TestMemorySource_EmitsEventsThenEOF(t *testing.T) {
+	cfg := mustEncode(t, memory.SourceConfig{Events: [][]byte{
+		[]byte("a"), []byte("b"), []byte("c"),
+	}})
+
+	op, err := memory.SourceFactory()(context.Background(), cfg, worker.TaskContext{})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	if err := op.Open(context.Background()); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer op.Close()
+
+	batch1, err := op.ReadBatch(context.Background())
+	if err != nil {
+		t.Fatalf("ReadBatch: %v", err)
+	}
+	if len(batch1) != 3 {
+		t.Fatalf("first batch len: got %d want 3", len(batch1))
+	}
+	for i, ev := range batch1 {
+		if string(ev.Value) != string([]byte{byte('a' + i)}) {
+			t.Errorf("batch[%d]: got %q want %q", i, ev.Value, []byte{byte('a' + i)})
+		}
+	}
+
+	// Subsequent reads should return nil to signal EOF.
+	batch2, err := op.ReadBatch(context.Background())
+	if err != nil {
+		t.Fatalf("ReadBatch (2): %v", err)
+	}
+	if batch2 != nil {
+		t.Fatalf("expected nil batch on EOF, got %v", batch2)
+	}
+}
+
+func TestMemorySource_EmptyConfig(t *testing.T) {
+	op, err := memory.SourceFactory()(context.Background(), nil, worker.TaskContext{})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	batch, err := op.ReadBatch(context.Background())
+	if err != nil {
+		t.Fatalf("ReadBatch: %v", err)
+	}
+	if len(batch) != 0 {
+		t.Fatalf("empty source should produce empty batch, got %d events", len(batch))
+	}
+}
+
+func TestMemorySource_BadConfig(t *testing.T) {
+	_, err := memory.SourceFactory()(context.Background(), []byte{0xff, 0xfe, 0xfd}, worker.TaskContext{})
+	if err == nil {
+		t.Fatal("expected decode error on garbage config")
+	}
+}
+
+func TestMemorySink_CapturesAndResets(t *testing.T) {
+	id := "test-sink-capture"
+	memory.Reset(id)
+	t.Cleanup(func() { memory.Reset(id) })
+
+	cfg := mustEncode(t, memory.SinkConfig{SinkID: id})
+	op, err := memory.SinkFactory()(context.Background(), cfg, worker.TaskContext{})
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	defer op.Close()
+
+	want := [][]byte{[]byte("x"), []byte("y"), []byte("z")}
+	for _, v := range want {
+		if err := op.Write(context.Background(), engine.Event{Value: v}); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	got := memory.Collected(id)
+	if len(got) != len(want) {
+		t.Fatalf("collected len: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if string(got[i].Value) != string(want[i]) {
+			t.Errorf("collected[%d]: got %q want %q", i, got[i].Value, want[i])
+		}
+	}
+
+	// Reset the specific id and verify the slice is now empty.
+	memory.Reset(id)
+	if got := memory.Collected(id); len(got) != 0 {
+		t.Fatalf("after Reset, collected should be empty; got %d", len(got))
+	}
+}
+
+func TestMemorySink_CollectedReturnsCopy(t *testing.T) {
+	id := "test-sink-copy"
+	memory.Reset(id)
+	t.Cleanup(func() { memory.Reset(id) })
+
+	cfg := mustEncode(t, memory.SinkConfig{SinkID: id})
+	op, _ := memory.SinkFactory()(context.Background(), cfg, worker.TaskContext{})
+	_ = op.Write(context.Background(), engine.Event{Value: []byte("v")})
+
+	first := memory.Collected(id)
+	if len(first) != 1 {
+		t.Fatalf("expected 1, got %d", len(first))
+	}
+	first[0].Value = []byte("MUTATED")
+
+	second := memory.Collected(id)
+	if string(second[0].Value) != "v" {
+		t.Fatalf("Collected should return a copy; got mutation %q", second[0].Value)
+	}
+}
+
+func TestMemorySink_IsolationByID(t *testing.T) {
+	idA := "isolated-A"
+	idB := "isolated-B"
+	memory.Reset(idA)
+	memory.Reset(idB)
+	t.Cleanup(func() { memory.Reset(idA); memory.Reset(idB) })
+
+	mkSink := func(id string) engine.SinkOperator {
+		cfg := mustEncode(t, memory.SinkConfig{SinkID: id})
+		op, err := memory.SinkFactory()(context.Background(), cfg, worker.TaskContext{})
+		if err != nil {
+			t.Fatalf("factory: %v", err)
+		}
+		return op
+	}
+
+	a := mkSink(idA)
+	b := mkSink(idB)
+	_ = a.Write(context.Background(), engine.Event{Value: []byte("a1")})
+	_ = b.Write(context.Background(), engine.Event{Value: []byte("b1")})
+	_ = a.Write(context.Background(), engine.Event{Value: []byte("a2")})
+
+	gotA := memory.Collected(idA)
+	gotB := memory.Collected(idB)
+	if len(gotA) != 2 || string(gotA[0].Value) != "a1" || string(gotA[1].Value) != "a2" {
+		t.Fatalf("sink A mismatch: %v", valuesOf(gotA))
+	}
+	if len(gotB) != 1 || string(gotB[0].Value) != "b1" {
+		t.Fatalf("sink B mismatch: %v", valuesOf(gotB))
+	}
+}
+
+func valuesOf(events []engine.Event) []string {
+	out := make([]string, len(events))
+	for i, e := range events {
+		out[i] = string(e.Value)
+	}
+	return out
+}

--- a/sdk/connectors/memory/sink.go
+++ b/sdk/connectors/memory/sink.go
@@ -1,0 +1,86 @@
+package memory
+
+import (
+	"context"
+	"sync"
+
+	"github.com/tarungka/wire/internal/engine"
+	"github.com/tarungka/wire/internal/protocol"
+	"github.com/tarungka/wire/internal/worker"
+)
+
+// SinkConfig is the msgpack-encoded configuration carried in
+// OperatorDescriptor.Config for a memory sink.
+type SinkConfig struct {
+	// SinkID is a test-chosen identifier used to retrieve collected events
+	// from the package-level registry via Collected(sinkID).
+	SinkID string `codec:"id"`
+}
+
+// SinkFactory returns a worker.SinkFactory that builds a memory sink from
+// SinkConfig bytes.
+func SinkFactory() worker.SinkFactory {
+	return func(_ context.Context, cfg []byte, _ worker.TaskContext) (engine.SinkOperator, error) {
+		var sc SinkConfig
+		if len(cfg) > 0 {
+			if err := protocol.DecodeMsgPack(cfg, &sc); err != nil {
+				return nil, err
+			}
+		}
+		return &memorySink{id: sc.SinkID}, nil
+	}
+}
+
+// memorySink appends each received event's Value to a slice stored in the
+// package-level registry keyed by SinkID. Integration tests read back with
+// Collected(sinkID).
+type memorySink struct {
+	id string
+}
+
+func (s *memorySink) Open(_ context.Context) error        { return nil }
+func (s *memorySink) Close() error                        { return nil }
+func (s *memorySink) Checkpoint(_ uint64) ([]byte, error) { return nil, nil }
+
+func (s *memorySink) Write(_ context.Context, event engine.Event) error {
+	append_(s.id, event)
+	return nil
+}
+
+var _ engine.SinkOperator = (*memorySink)(nil)
+
+// sinkStore is the package-level registry of captured events, keyed by
+// SinkID. It allows tests to retrieve output that was produced inside the
+// worker's factory-instantiated sink.
+var (
+	sinkStoreMu sync.RWMutex
+	sinkStore   = make(map[string][]engine.Event)
+)
+
+func append_(id string, e engine.Event) {
+	sinkStoreMu.Lock()
+	defer sinkStoreMu.Unlock()
+	sinkStore[id] = append(sinkStore[id], e)
+}
+
+// Collected returns a copy of all events captured by the sink with the given
+// SinkID. Intended for use only from tests.
+func Collected(id string) []engine.Event {
+	sinkStoreMu.RLock()
+	defer sinkStoreMu.RUnlock()
+	out := make([]engine.Event, len(sinkStore[id]))
+	copy(out, sinkStore[id])
+	return out
+}
+
+// Reset clears the captured events for a SinkID (or all SinkIDs if id=="").
+// Intended for use only from tests.
+func Reset(id string) {
+	sinkStoreMu.Lock()
+	defer sinkStoreMu.Unlock()
+	if id == "" {
+		sinkStore = make(map[string][]engine.Event)
+		return
+	}
+	delete(sinkStore, id)
+}

--- a/sdk/connectors/memory/source.go
+++ b/sdk/connectors/memory/source.go
@@ -1,0 +1,65 @@
+// Package memory provides in-memory reference Source and Sink connectors
+// for testing and examples. They are not intended for production use.
+//
+// Usage (in a user's wire-worker main):
+//
+//	worker.RegisterSource("memory-source", memory.SourceFactory())
+//	worker.RegisterSink("memory-sink", memory.SinkFactory())
+package memory
+
+import (
+	"context"
+
+	"github.com/tarungka/wire/internal/engine"
+	"github.com/tarungka/wire/internal/protocol"
+	"github.com/tarungka/wire/internal/worker"
+)
+
+// SourceConfig is the msgpack-encoded configuration carried in
+// OperatorDescriptor.Config for a memory source.
+type SourceConfig struct {
+	// Events is the sequence of records the source will emit. Each
+	// inner []byte is the Value; Key defaults to nil.
+	Events [][]byte `codec:"e"`
+}
+
+// SourceFactory returns a worker.SourceFactory that builds a memory source
+// from SourceConfig bytes.
+func SourceFactory() worker.SourceFactory {
+	return func(_ context.Context, cfg []byte, _ worker.TaskContext) (engine.SourceOperator, error) {
+		var sc SourceConfig
+		if len(cfg) > 0 {
+			if err := protocol.DecodeMsgPack(cfg, &sc); err != nil {
+				return nil, err
+			}
+		}
+		return &memorySource{events: sc.Events}, nil
+	}
+}
+
+// memorySource emits a fixed slice of events once and then signals EOF.
+type memorySource struct {
+	events [][]byte
+	done   bool
+}
+
+func (s *memorySource) Open(_ context.Context) error        { return nil }
+func (s *memorySource) Close() error                        { return nil }
+func (s *memorySource) Checkpoint(_ uint64) ([]byte, error) { return nil, nil }
+
+func (s *memorySource) ReadBatch(_ context.Context) ([]engine.Event, error) {
+	if s.done {
+		return nil, nil
+	}
+	s.done = true
+	out := make([]engine.Event, 0, len(s.events))
+	for _, v := range s.events {
+		out = append(out, engine.Event{Value: v})
+	}
+	return out, nil
+}
+
+// GenerateWatermark returns 0 — memory source emits untimed events.
+func (s *memorySource) GenerateWatermark() int64 { return 0 }
+
+var _ engine.SourceOperator = (*memorySource)(nil)

--- a/sdk/data_stream.go
+++ b/sdk/data_stream.go
@@ -52,6 +52,62 @@ func (ds *DataStream) flatMapWithName(fn FlatMapFunc, name string) *DataStream {
 	return &DataStream{env: ds.env, nodeID: id}
 }
 
+// MapNamed adds a Cluster-mode map operator identified by className. The
+// worker's Registry must have a MapFactory registered under this name. The
+// config bytes are passed verbatim to the factory at deploy time.
+func (ds *DataStream) MapNamed(name, className string, config []byte) *DataStream {
+	node := &StreamNode{
+		Name:      name,
+		Type:      NodeMap,
+		ClassName: className,
+		Config:    config,
+	}
+	id := ds.env.graph.addNode(node)
+	ds.env.graph.addEdge(ds.nodeID, id, ShuffleForward)
+	return &DataStream{env: ds.env, nodeID: id}
+}
+
+// FlatMapNamed adds a Cluster-mode flat-map operator identified by className.
+func (ds *DataStream) FlatMapNamed(name, className string, config []byte) *DataStream {
+	node := &StreamNode{
+		Name:      name,
+		Type:      NodeFlatMap,
+		ClassName: className,
+		Config:    config,
+	}
+	id := ds.env.graph.addNode(node)
+	ds.env.graph.addEdge(ds.nodeID, id, ShuffleForward)
+	return &DataStream{env: ds.env, nodeID: id}
+}
+
+// FilterNamed adds a Cluster-mode filter operator identified by className.
+// (Filters are registered as MapFactory instances: the factory returns an
+// engine.MapOperator whose Map returns a zero event for filtered records.)
+func (ds *DataStream) FilterNamed(name, className string, config []byte) *DataStream {
+	node := &StreamNode{
+		Name:      name,
+		Type:      NodeFilter,
+		ClassName: className,
+		Config:    config,
+	}
+	id := ds.env.graph.addNode(node)
+	ds.env.graph.addEdge(ds.nodeID, id, ShuffleForward)
+	return &DataStream{env: ds.env, nodeID: id}
+}
+
+// AddSinkNamed adds a Cluster-mode terminal sink identified by className.
+func (ds *DataStream) AddSinkNamed(name, className string, config []byte) *DataStream {
+	node := &StreamNode{
+		Name:      name,
+		Type:      NodeSink,
+		ClassName: className,
+		Config:    config,
+	}
+	id := ds.env.graph.addNode(node)
+	ds.env.graph.addEdge(ds.nodeID, id, ShuffleForward)
+	return &DataStream{env: ds.env, nodeID: id}
+}
+
 // Filter keeps only events that satisfy the predicate.
 func (ds *DataStream) Filter(fn FilterFunc) *DataStream {
 	return ds.filterWithName(fn, "")

--- a/sdk/environment.go
+++ b/sdk/environment.go
@@ -14,6 +14,7 @@ type StreamExecutionEnvironment struct {
 	checkpointTimeout  time.Duration
 	restartStrategy    RestartStrategy
 	mode               ExecutionMode
+	coordinatorURL     string
 	graph              *StreamGraph
 	executed           bool
 }
@@ -59,6 +60,13 @@ func (env *StreamExecutionEnvironment) SetMode(mode ExecutionMode) *StreamExecut
 	return env
 }
 
+// SetCoordinator sets the coordinator base URL for Cluster mode (e.g.
+// "http://localhost:4001"). Ignored in Embedded mode.
+func (env *StreamExecutionEnvironment) SetCoordinator(url string) *StreamExecutionEnvironment {
+	env.coordinatorURL = url
+	return env
+}
+
 // AddSource adds a source to the pipeline, returning a DataStream.
 func (env *StreamExecutionEnvironment) AddSource(source Source) *DataStream {
 	return env.AddSourceWithName("", source)
@@ -70,6 +78,20 @@ func (env *StreamExecutionEnvironment) AddSourceWithName(name string, source Sou
 		Name:   name,
 		Type:   NodeSource,
 		Source: source,
+	}
+	id := env.graph.addNode(node)
+	return &DataStream{env: env, nodeID: id}
+}
+
+// AddSourceNamed adds a Cluster-mode source identified by className. The
+// worker's Registry must have a SourceFactory registered under this name.
+// The config bytes are passed verbatim to the factory at deploy time.
+func (env *StreamExecutionEnvironment) AddSourceNamed(name, className string, config []byte) *DataStream {
+	node := &StreamNode{
+		Name:      name,
+		Type:      NodeSource,
+		ClassName: className,
+		Config:    config,
 	}
 	id := env.graph.addNode(node)
 	return &DataStream{env: env, nodeID: id}
@@ -96,7 +118,10 @@ func (env *StreamExecutionEnvironment) ExecuteWithName(ctx context.Context, jobN
 		executor := &embeddedExecutor{env: env}
 		return executor.run(ctx, jobName)
 	case Cluster:
-		executor := &clusterExecutor{}
+		if err := env.graph.validateForCluster(); err != nil {
+			return nil, err
+		}
+		executor := &clusterExecutor{env: env}
 		return executor.run(ctx, jobName)
 	default:
 		return nil, fmt.Errorf("%w: unknown execution mode %d", ErrInvalidConfig, env.mode)

--- a/sdk/graph_converter.go
+++ b/sdk/graph_converter.go
@@ -28,6 +28,8 @@ func (g *StreamGraph) toJobGraph(defaultParallelism int) rpc.JobGraph {
 			Name:        node.Name,
 			Type:        nodeTypeToRPC(node.Type),
 			Parallelism: int32(p),
+			ClassName:   node.ClassName,
+			Config:      node.Config,
 		})
 	}
 

--- a/sdk/stream_graph.go
+++ b/sdk/stream_graph.go
@@ -34,7 +34,16 @@ type StreamNode struct {
 	Type        StreamNodeType
 	Parallelism int
 
-	// Operator function pointers — exactly one is set.
+	// ClassName identifies a registered operator factory on the worker.
+	// Required for Cluster mode (see worker.Registry); unused in Embedded.
+	ClassName string
+	// Config carries the operator-specific configuration bytes that are
+	// passed verbatim to the worker factory at deploy time. Typically
+	// msgpack-encoded. Only meaningful in Cluster mode.
+	Config []byte
+
+	// Operator function pointers — exactly one is set in Embedded mode.
+	// In Cluster mode these are nil and ClassName is used instead.
 	MapFn      MapFunc
 	FlatMapFn  FlatMapFunc
 	FilterFn   FilterFunc
@@ -96,6 +105,24 @@ func (g *StreamGraph) addEdge(sourceID, targetID int, shuffle ShuffleType) {
 		TargetID: targetID,
 		Shuffle:  shuffle,
 	})
+}
+
+// validateForCluster checks that every node has a ClassName populated.
+// In Cluster mode, operators are resolved by name from the worker's registry;
+// inline closures (MapFn/FilterFn/...) cannot be serialized across the RPC
+// boundary and so are not allowed in a Cluster-mode graph.
+func (g *StreamGraph) validateForCluster() error {
+	for _, node := range g.nodes {
+		if node.ClassName == "" {
+			return fmt.Errorf(
+				"%w: cluster-mode graph requires ClassName on every node; "+
+					"node %q (type %d) has no ClassName — did you use .Map(closure) "+
+					"instead of .MapNamed(name, cfg)?",
+				ErrInvalidConfig, node.Name, node.Type,
+			)
+		}
+	}
+	return nil
 }
 
 // validate checks the graph for structural errors.

--- a/sdk/stream_graph_test.go
+++ b/sdk/stream_graph_test.go
@@ -2,8 +2,37 @@ package sdk
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
+
+func TestValidateForCluster_AllNodesNamed(t *testing.T) {
+	g := newStreamGraph()
+	g.addNode(&StreamNode{Name: "src", Type: NodeSource, ClassName: "memory-source"})
+	g.addNode(&StreamNode{Name: "snk", Type: NodeSink, ClassName: "memory-sink"})
+	if err := g.validateForCluster(); err != nil {
+		t.Fatalf("validateForCluster: unexpected error: %v", err)
+	}
+}
+
+func TestValidateForCluster_RejectsEmptyClassName(t *testing.T) {
+	g := newStreamGraph()
+	g.addNode(&StreamNode{Name: "src", Type: NodeSource, ClassName: "memory-source"})
+	g.addNode(&StreamNode{Name: "m", Type: NodeMap}) // no ClassName -> closure-style
+	g.addNode(&StreamNode{Name: "snk", Type: NodeSink, ClassName: "memory-sink"})
+
+	err := g.validateForCluster()
+	if err == nil {
+		t.Fatal("expected validateForCluster to reject node with empty ClassName")
+	}
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("error %v should wrap ErrInvalidConfig", err)
+	}
+	// Error message should hint at the fix.
+	if !strings.Contains(err.Error(), "MapNamed") && !strings.Contains(err.Error(), "ClassName") {
+		t.Fatalf("error %q should hint at the fix", err)
+	}
+}
 
 func TestGraphValidateEmptyPipeline(t *testing.T) {
 	g := newStreamGraph()


### PR DESCRIPTION
Before this change, the worker was a heartbeat stub — it accepted DeployTask commands but never instantiated operators or processed any data. Submitted jobs transitioned to DEPLOYING and hung there. This is Phase 1 of the distributed-execution plan.

What's now wired end-to-end:
- SDK Cluster mode (sdk/cluster.go): serializes the JobGraph and submits over HTTP, then polls /api/v1/jobs/{id} until terminal.
- SDK named-operator API (AddSourceNamed, MapNamed, FilterNamed, FlatMapNamed, AddSinkNamed): ClassName+Config on each StreamNode, validated in validateForCluster. Closure-based .Map() etc still work for Embedded mode.
- Coordinator accepts graph_bytes in POST /api/v1/jobs and persists the msgpack JobGraph as the job's config.
- Scheduler generateTaskDescriptors decodes the JobGraph, topo-sorts operators, and embeds the linear OperatorChain in every TaskDescriptor (Phase 2 will split at shuffle boundaries).
- TaskDescriptor gains OperatorChain []OperatorDescriptor.
- Worker Registry (internal/worker/registry.go) maps ClassName to SourceFactory/MapFactory/FlatMapFactory/SinkFactory. Package-level default registry + RegisterSource/Map/FlatMap/Sink convenience funcs.
- taskExecutor (internal/worker/task_executor.go) mirrors sdk/embedded.go:runLinearInstance: builds operators via Registry, wires engine.RunSourceReader + engine.RunOperatorChain.
- handleDeployTask now actually runs tasks; reports Running on entry and Finished/Failed/Canceled on exit.
- Coordinator transitions JobRunning -> JobFinishing -> JobFinished when all tasks report Finished.
- Reference connectors sdk/connectors/memory/ (MemorySource + MemorySink with test-side retrieval via Collected()).
- TransportServer split into Listen() + Serve() + Addr() so tests can bind to :0 and retrieve the actual address.

Verification:
- New integration test internal/worker/integration_test.go boots a single-node coordinator + in-process worker, submits a Source -> Map(ToUpper) -> Sink pipeline via the SDK in Cluster mode, and asserts the sink received the uppercased events.
- go test ./... green across config, coordinator, engine, keygroup, protocol, rpc, transport, worker, sdk.