### PR TITLE
feat(observability): k6 load test stack + extended Grafana dashboard

### DIFF
--- a/examples/observability-stack/Dockerfile.wire
+++ b/examples/observability-stack/Dockerfile.wire
@@ -27,6 +27,10 @@ RUN go build -o /out/wire-worker-example ./examples/wire-worker-example/.
 # Build the example submitter so the stack can drive load.
 RUN go build -o /out/submit-uppercase-job ./examples/submit-uppercase-job/.
 
+# Build the graph-bytes printer used by the k6 load service to seed the
+# request body with a real (msgpack-encoded) JobGraph.
+RUN go build -o /out/print-uppercase-graph ./examples/print-uppercase-graph/.
+
 #######################################################################
 FROM alpine:3.20
 
@@ -36,6 +40,7 @@ WORKDIR /app
 COPY --from=builder /out/wire /usr/local/bin/wire
 COPY --from=builder /out/wire-worker-example /usr/local/bin/wire-worker-example
 COPY --from=builder /out/submit-uppercase-job /usr/local/bin/submit-uppercase-job
+COPY --from=builder /out/print-uppercase-graph /usr/local/bin/print-uppercase-graph
 
 RUN mkdir -p /data
 VOLUME /data

--- a/examples/observability-stack/README.md
+++ b/examples/observability-stack/README.md
@@ -14,6 +14,7 @@ health and latency distributions from the OTel instrumentation.
 | `prometheus` | `9091` | Scrapes wire `/metrics` every 5 s |
 | `grafana` | `3000` | Pre-provisioned `Wire / coordinator overview` dashboard (anonymous viewer enabled) |
 | `load` | — | Optional short-runner that submits sample jobs (profile `load`) |
+| `k6` | — | Optional k6 load generator that drives `POST /api/v1/jobs` at a configurable arrival rate (profile `k6`) |
 
 ## Prerequisites
 
@@ -97,6 +98,52 @@ go run ../../examples/submit-uppercase-job \
 You should see `wire_rpc_server_requests_total{method="SubmitJob"}` tick
 up in the dashboard, and the corresponding job appear in
 `GET /api/v1/jobs`.
+
+## Load testing with k6
+
+The `k6` profile drives sustained `POST /api/v1/jobs` traffic against the
+coordinator and reports p50/p95/p99 latency, RPS, and error rate.
+
+```sh
+# 30 s at 20 jobs/s (defaults)
+docker compose --profile k6 run --rm k6
+
+# 1 min at 50 jobs/s
+RPS=50 DURATION=1m docker compose --profile k6 run --rm k6
+```
+
+**What is being measured.** k6 records the HTTP RTT for the submit
+endpoint — JSON parse + name-uniqueness check + two PebbleDB writes
+(job meta + config) + scheduler kick + JSON encode of the response. This
+is bounded below by the Pebble fsync floor (~6 ms on most disks).
+
+**What this is NOT.** k6 cannot see the full POST → worker-receives-DeployTask
+dispatch path on its own. To watch that, leave the Grafana dashboard
+open during the run and look at the `wire_rpc_*` and `wire_pebble_*`
+histograms — those reflect what the coordinator and worker actually
+spent time on.
+
+**How it works.** A short-lived `k6-graph-init` container runs
+`print-uppercase-graph` once and writes the base64-encoded
+`Source -> Map(upper) -> Sink` graph to a shared volume. The k6
+container reads that file and feeds it into every request body via
+`--env GRAPH_BYTES=...`, so each submission is a real graph the worker
+actually deploys. With 4 task slots on the worker and `parallelism=1`,
+beyond ~4 concurrent in-flight jobs the scheduler queues the rest in
+`CREATED` state — that's expected and doesn't change the HTTP latency
+distribution.
+
+**Tuning knobs (env vars):**
+
+| Var | Default | Notes |
+|---|---|---|
+| `RPS` | `20` | Target arrival rate (jobs/s) |
+| `DURATION` | `30s` | k6 duration string (e.g. `2m`, `5m`) |
+| `PRE_VUS` | `20` | Pre-allocated virtual users |
+| `MAX_VUS` | `200` | Hard cap on VU pool growth |
+
+The script asserts `p95 < 500 ms` and `p99 < 1 s` on the submit endpoint;
+exceeding those flags the run as failed in k6's exit code.
 
 ## Iterating on wire
 

--- a/examples/observability-stack/docker-compose.yml
+++ b/examples/observability-stack/docker-compose.yml
@@ -132,7 +132,55 @@ services:
       coordinator:
         condition: service_healthy
 
+  # Init container: produces the static graph_bytes blob the k6 service
+  # uses as its request body. Writes to a shared volume that the k6
+  # service mounts read-only. Runs once per `up` (or `docker compose run`).
+  k6-graph-init:
+    image: wire:local
+    container_name: wire-k6-graph-init
+    profiles: ["k6"]
+    entrypoint: ["sh", "-c"]
+    command:
+      - "print-uppercase-graph > /shared/graph_bytes.txt && echo wrote /shared/graph_bytes.txt"
+    volumes:
+      - k6-shared:/shared
+    depends_on:
+      coordinator:
+        condition: service_healthy
+
+  # k6 load generator. Reads GRAPH_BYTES from the shared volume produced
+  # by k6-graph-init, then drives POST /api/v1/jobs at a configurable
+  # arrival rate.
+  #
+  # Run with:
+  #   docker compose --profile k6 run --rm k6
+  # Override knobs:
+  #   docker compose --profile k6 run --rm -e RPS=50 -e DURATION=1m k6
+  k6:
+    image: grafana/k6:0.54.0
+    container_name: wire-k6
+    profiles: ["k6"]
+    depends_on:
+      coordinator:
+        condition: service_healthy
+      k6-graph-init:
+        condition: service_completed_successfully
+    volumes:
+      - ./k6:/scripts:ro
+      - k6-shared:/shared:ro
+    environment:
+      WIRE_API: "http://coordinator:4001"
+      RPS: "${RPS:-20}"
+      DURATION: "${DURATION:-30s}"
+    entrypoint: ["/bin/sh", "-c"]
+    # The shell reads graph_bytes.txt and forwards it as a k6 --env so
+    # the script's __ENV.GRAPH_BYTES sees it. The double-$$ escapes the
+    # variable from compose's own interpolation.
+    command:
+      - 'k6 run --env GRAPH_BYTES=$$(cat /shared/graph_bytes.txt) /scripts/submit_jobs.js'
+
 volumes:
   coordinator-data:
   prometheus-data:
   grafana-data:
+  k6-shared:

--- a/examples/observability-stack/grafana/dashboards/wire.json
+++ b/examples/observability-stack/grafana/dashboards/wire.json
@@ -3,7 +3,7 @@
   "uid": "wire-coordinator",
   "tags": ["wire"],
   "schemaVersion": 39,
-  "version": 1,
+  "version": 3,
   "refresh": "5s",
   "time": { "from": "now-15m", "to": "now" },
   "timepicker": {},
@@ -20,20 +20,34 @@
     },
     {
       "type": "timeseries",
-      "title": "HTTP requests/sec by route",
+      "title": "HTTP requests/sec by route (avg vs peak)",
       "id": 10,
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Two views of the same metric: the 1-minute smoothed rate (steady-state) and the 15-second instantaneous rate (catches bursts). Short tests at high RPS will show the peak line spiking while the avg line lags.",
       "targets": [
         {
           "expr": "sum(rate(wire_http_requests_total[1m])) by (route)",
-          "legendFormat": "{{route}}",
+          "legendFormat": "{{route}} (1m avg)",
           "refId": "A"
+        },
+        {
+          "expr": "sum(rate(wire_http_requests_total[15s])) by (route)",
+          "legendFormat": "{{route}} (15s peak)",
+          "refId": "B"
         }
       ],
       "fieldConfig": {
         "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*\\(15s peak\\)$" },
+            "properties": [
+              { "id": "custom.lineStyle", "value": { "fill": "dash", "dash": [10, 5] } },
+              { "id": "custom.fillOpacity", "value": 0 }
+            ]
+          }
+        ]
       },
       "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
     },
@@ -231,6 +245,216 @@
         { "expr": "rate(process_cpu_seconds_total{job=\"wire-coordinator\"}[1m])", "legendFormat": "cores", "refId": "A" }
       ],
       "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "OS threads (GOMAXPROCS reference)",
+      "id": 43,
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 52 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Total OS threads created by the Go runtime. Spikes above GOMAXPROCS usually mean blocking syscalls (e.g. cgo, file I/O); steady growth is a thread leak.",
+      "targets": [
+        { "expr": "go_threads{job=\"wire-coordinator\"}", "legendFormat": "threads", "refId": "A" },
+        { "expr": "go_sched_gomaxprocs_threads{job=\"wire-coordinator\"}", "legendFormat": "GOMAXPROCS", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Open file descriptors",
+      "id": 44,
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 52 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Open FDs vs. the soft limit. Steady growth without bound is a leak (unclosed conns / files); approaching max means EMFILE incoming.",
+      "targets": [
+        { "expr": "process_open_fds{job=\"wire-coordinator\"}", "legendFormat": "open", "refId": "A" },
+        { "expr": "process_max_fds{job=\"wire-coordinator\"}", "legendFormat": "max (rlimit)", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+    },
+    {
+      "type": "stat",
+      "title": "Process uptime",
+      "id": 45,
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 52 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "targets": [
+        { "expr": "time() - process_start_time_seconds{job=\"wire-coordinator\"}", "legendFormat": "uptime", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "graphMode": "area", "colorMode": "value" }
+    },
+
+    {
+      "type": "row",
+      "title": "Go GC",
+      "id": 5,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 58 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "GC pause latency (p50 / p75 / max)",
+      "id": 50,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 59 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Stop-the-world pause time per GC cycle. The Go collector exposes a 5-bucket summary {0, .25, .5, .75, 1}; max above ~10 ms sustained means tail latency is GC-bound.",
+      "targets": [
+        { "expr": "go_gc_duration_seconds{quantile=\"0.5\",job=\"wire-coordinator\"}", "legendFormat": "p50", "refId": "A" },
+        { "expr": "go_gc_duration_seconds{quantile=\"0.75\",job=\"wire-coordinator\"}", "legendFormat": "p75", "refId": "B" },
+        { "expr": "go_gc_duration_seconds{quantile=\"1\",job=\"wire-coordinator\"}", "legendFormat": "max", "refId": "C" }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 0, "axisScale": "log" } }
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "GC cycles/sec & time since last GC",
+      "id": 51,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 59 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Frequency of full GC cycles, and seconds since the last cycle finished. High cycles/sec + low pauses is fine; rising cycle rate without rising allocation usually means heap fragmentation.",
+      "targets": [
+        { "expr": "rate(go_gc_duration_seconds_count{job=\"wire-coordinator\"}[1m])", "legendFormat": "cycles/sec", "refId": "A" },
+        { "expr": "time() - go_memstats_last_gc_time_seconds{job=\"wire-coordinator\"}", "legendFormat": "since last GC (s)", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Heap usage vs next-GC trigger",
+      "id": 52,
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 67 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "When heap_alloc approaches next_gc, the GC fires and heap_alloc drops. The gap between them is your headroom.",
+      "targets": [
+        { "expr": "go_memstats_heap_alloc_bytes{job=\"wire-coordinator\"}", "legendFormat": "heap_alloc", "refId": "A" },
+        { "expr": "go_memstats_next_gc_bytes{job=\"wire-coordinator\"}", "legendFormat": "next_gc trigger", "refId": "B" },
+        { "expr": "go_gc_gomemlimit_bytes{job=\"wire-coordinator\"}", "legendFormat": "GOMEMLIMIT", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "GC stop-the-world overhead (% of wall time)",
+      "id": 53,
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 67 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Fraction of wall-clock time spent inside GC stop-the-world phases. Sustained > 5% is the classic 'tune the heap' signal — bump GOGC or GOMEMLIMIT.",
+      "targets": [
+        { "expr": "rate(go_gc_duration_seconds_sum{job=\"wire-coordinator\"}[1m])", "legendFormat": "GC STW fraction", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+    },
+
+    {
+      "type": "row",
+      "title": "Go memory",
+      "id": 6,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 74 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Heap composition",
+      "id": 60,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 75 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Heap memory split into live (heap_alloc), in-use spans (heap_inuse), idle (heap_idle), and released-to-OS (heap_released). heap_inuse - heap_alloc is fragmentation overhead.",
+      "targets": [
+        { "expr": "go_memstats_heap_alloc_bytes{job=\"wire-coordinator\"}", "legendFormat": "live (heap_alloc)", "refId": "A" },
+        { "expr": "go_memstats_heap_inuse_bytes{job=\"wire-coordinator\"}", "legendFormat": "in-use (heap_inuse)", "refId": "B" },
+        { "expr": "go_memstats_heap_idle_bytes{job=\"wire-coordinator\"}", "legendFormat": "idle (heap_idle)", "refId": "C" },
+        { "expr": "go_memstats_heap_released_bytes{job=\"wire-coordinator\"}", "legendFormat": "released to OS", "refId": "D" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Non-heap memory (stack / metadata)",
+      "id": 61,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 75 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Stack memory grows with goroutine count; mspan/mcache grow with heap size. A goroutine leak shows here as steadily climbing stack_inuse.",
+      "targets": [
+        { "expr": "go_memstats_stack_inuse_bytes{job=\"wire-coordinator\"}", "legendFormat": "stack_inuse", "refId": "A" },
+        { "expr": "go_memstats_mspan_inuse_bytes{job=\"wire-coordinator\"}", "legendFormat": "mspan_inuse", "refId": "B" },
+        { "expr": "go_memstats_mcache_inuse_bytes{job=\"wire-coordinator\"}", "legendFormat": "mcache_inuse", "refId": "C" },
+        { "expr": "go_memstats_gc_sys_bytes{job=\"wire-coordinator\"}", "legendFormat": "gc metadata", "refId": "D" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Allocation rate (bytes/sec)",
+      "id": 62,
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 83 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Bytes allocated per second on the heap. Higher = more GC pressure. Pair with the allocations/sec panel to spot allocation-heavy hot paths.",
+      "targets": [
+        { "expr": "rate(go_memstats_alloc_bytes_total{job=\"wire-coordinator\"}[1m])", "legendFormat": "bytes/sec", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Allocations & frees / sec",
+      "id": 63,
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 83 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Object-level alloc/free rate. heap_objects (live) is the steady-state live-object count.",
+      "targets": [
+        { "expr": "rate(go_memstats_mallocs_total{job=\"wire-coordinator\"}[1m])", "legendFormat": "mallocs/sec", "refId": "A" },
+        { "expr": "rate(go_memstats_frees_total{job=\"wire-coordinator\"}[1m])", "legendFormat": "frees/sec", "refId": "B" },
+        { "expr": "go_memstats_heap_objects{job=\"wire-coordinator\"}", "legendFormat": "live objects", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
+    },
+
+    {
+      "type": "row",
+      "title": "Network & memory map",
+      "id": 7,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 90 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Network throughput (rate)",
+      "id": 70,
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 91 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Bytes per second across all process sockets. Coordinator is typically: HTTP API ingress + worker RPC bidi + Prometheus scrape egress.",
+      "targets": [
+        { "expr": "rate(process_network_receive_bytes_total{job=\"wire-coordinator\"}[1m])", "legendFormat": "rx", "refId": "A" },
+        { "expr": "rate(process_network_transmit_bytes_total{job=\"wire-coordinator\"}[1m])", "legendFormat": "tx", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Resident vs virtual vs Go-sys memory",
+      "id": 71,
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 91 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "RSS is what the OS sees as resident; virtual is the address-space size (includes mmaped Pebble files). A big VSZ-RSS gap is normal for memory-mapped DBs. go_memstats_sys is what the Go runtime has obtained from the OS.",
+      "targets": [
+        { "expr": "process_resident_memory_bytes{job=\"wire-coordinator\"}", "legendFormat": "RSS", "refId": "A" },
+        { "expr": "process_virtual_memory_bytes{job=\"wire-coordinator\"}", "legendFormat": "virtual (VSZ)", "refId": "B" },
+        { "expr": "go_memstats_sys_bytes{job=\"wire-coordinator\"}", "legendFormat": "Go runtime sys", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
     }
   ]
 }

--- a/examples/observability-stack/k6/submit_jobs.js
+++ b/examples/observability-stack/k6/submit_jobs.js
@@ -1,0 +1,69 @@
+// k6 script — drive job submissions against a running coordinator.
+//
+// Measures HTTP submit latency for POST /api/v1/jobs at a configurable
+// arrival rate. Each request sends a real (Source -> Map(upper) -> Sink)
+// graph so the worker actually deploys and runs the job; the worker has
+// 4 task slots, so beyond ~4 concurrent in-flight jobs the scheduler
+// queues remaining ones in CREATED state and dispatches as slots free.
+//
+// What this measures: time from k6 sending POST to receiving 201. That is
+// roughly { JSON parse + name uniqueness check + 2x Pebble Set (job meta +
+// config) + scheduler kick + JSON encode of response }, dominated by the
+// Pebble fsync floor (~6 ms).
+//
+// What this does NOT measure: end-to-end dispatch latency (POST -> worker
+// receives DeployTask). Watch that in the Grafana dashboard via the
+// wire_rpc_* histograms while this script is running.
+//
+// Env knobs (all optional):
+//   WIRE_API     — coordinator URL (default http://localhost:4001)
+//   GRAPH_BYTES  — base64-encoded msgpack rpc.JobGraph (REQUIRED — produced
+//                  by print-uppercase-graph; the docker compose stack feeds
+//                  this in via the k6-graph-init shared volume)
+//   RPS          — target arrival rate per second (default 20)
+//   DURATION     — k6 duration string, e.g. 30s, 2m (default 30s)
+//   PRE_VUS      — pre-allocated VUs (default 20)
+//   MAX_VUS      — max VUs (default 200)
+
+import http from 'k6/http';
+import { check } from 'k6';
+
+const API = __ENV.WIRE_API || 'http://localhost:4001';
+const GRAPH = __ENV.GRAPH_BYTES;
+if (!GRAPH) {
+  throw new Error('GRAPH_BYTES env var is required (run print-uppercase-graph to produce it)');
+}
+
+export const options = {
+  scenarios: {
+    submit: {
+      executor: 'constant-arrival-rate',
+      rate: Number(__ENV.RPS || 20),
+      timeUnit: '1s',
+      duration: __ENV.DURATION || '30s',
+      preAllocatedVUs: Number(__ENV.PRE_VUS || 20),
+      maxVUs: Number(__ENV.MAX_VUS || 200),
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    'http_req_duration{name:submit_job}': ['p(95)<500', 'p(99)<1000'],
+  },
+};
+
+const payloadHeaders = { 'Content-Type': 'application/json' };
+
+export default function () {
+  const body = JSON.stringify({
+    name: `loadtest-${__VU}-${__ITER}-${Date.now()}`,
+    parallelism: 1,
+    graph_bytes: GRAPH,
+  });
+  const res = http.post(`${API}/api/v1/jobs`, body, {
+    headers: payloadHeaders,
+    tags: { name: 'submit_job' },
+  });
+  check(res, {
+    'status 201': (r) => r.status === 201,
+  });
+}

--- a/examples/print-uppercase-graph/main.go
+++ b/examples/print-uppercase-graph/main.go
@@ -1,0 +1,48 @@
+// print-uppercase-graph builds the same Source -> Map(upper) -> Sink graph as
+// submit-uppercase-job and prints its base64-encoded msgpack bytes to stdout.
+//
+// The output is the value the coordinator's POST /api/v1/jobs endpoint expects
+// in the "graph_bytes" field — useful for load tools (k6, vegeta) that need
+// a static blob to replay rather than rebuilding the graph in JS/JSON.
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/tarungka/wire/internal/protocol"
+	"github.com/tarungka/wire/internal/rpc"
+	"github.com/tarungka/wire/sdk/connectors/memory"
+)
+
+func main() {
+	srcCfg, err := protocol.EncodeMsgPack(memory.SourceConfig{
+		Events: [][]byte{[]byte("hello"), []byte("world"), []byte("wire")},
+	})
+	check(err)
+	sinkCfg, err := protocol.EncodeMsgPack(memory.SinkConfig{SinkID: "loadtest"})
+	check(err)
+
+	graph := rpc.JobGraph{
+		Operators: []rpc.OperatorDescriptor{
+			{OperatorID: "src", Name: "src", Type: rpc.OperatorTypeSource, Parallelism: 1, ClassName: "memory-source", Config: srcCfg},
+			{OperatorID: "upper", Name: "upper", Type: rpc.OperatorTypeMap, Parallelism: 1, ClassName: "upper"},
+			{OperatorID: "sink", Name: "sink", Type: rpc.OperatorTypeSink, Parallelism: 1, ClassName: "memory-sink", Config: sinkCfg},
+		},
+		Edges: []rpc.EdgeDescriptor{
+			{SourceOperatorID: "src", TargetOperatorID: "upper", Shuffle: rpc.ShuffleStrategyForward},
+			{SourceOperatorID: "upper", TargetOperatorID: "sink", Shuffle: rpc.ShuffleStrategyForward},
+		},
+	}
+	data, err := protocol.EncodeMsgPack(&graph)
+	check(err)
+	fmt.Println(base64.StdEncoding.EncodeToString(data))
+}
+
+func check(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
- New `k6` compose profile drives POST /api/v1/jobs at configurable RPS (RPS=, DURATION=, PRE_VUS=, MAX_VUS= env vars)
- print-uppercase-graph helper emits the static base64 JobGraph blob k6 sends as request bodies, so each submission is a real graph the worker actually deploys
- k6-graph-init init container writes the blob to a shared volume that the k6 service mounts read-only, keeping the k6 image stock (grafana/k6:0.54.0)
- Grafana dashboard grows from 4 rows to 7: adds Go GC (pause p50/p75/max, cycles/sec, heap vs next_gc trigger, STW % of wall time), Go memory (heap composition, non-heap stack/mspan/mcache, alloc rate, mallocs+ frees), Network & memory map (rx/tx, RSS vs VSZ vs Go-sys); existing Process row gains OS threads, FD usage vs rlimit, uptime
- HTTP requests/sec panel now plots both 1m smoothed avg and 15s peak so short load tests at high RPS show the real arrival rate, not the rate-window-diluted average